### PR TITLE
Feat/memberrequest

### DIFF
--- a/src/main/java/com/donut/prokindonutsweb/controller/HomeController.java
+++ b/src/main/java/com/donut/prokindonutsweb/controller/HomeController.java
@@ -55,9 +55,6 @@ public class HomeController {
     @GetMapping("/qh/inbound/status")
     public void QIstatus(){}
 
-    @GetMapping("/qh/member/request")
-    public void QMrequest(){}
-
     @GetMapping("/qh/franchise")
     public void Qfranchise(){}
 
@@ -69,8 +66,5 @@ public class HomeController {
 
     @GetMapping("/qh/product")
     public void Qproduct(){}
-
-//    @GetMapping("/qh/warehouse")
-//    public void Qwarehouse(){}
 
 }

--- a/src/main/java/com/donut/prokindonutsweb/controller/member/QhMemberRequestController.java
+++ b/src/main/java/com/donut/prokindonutsweb/controller/member/QhMemberRequestController.java
@@ -8,6 +8,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.Collections;
@@ -25,9 +26,9 @@ public class QhMemberRequestController {
         model.addAttribute("requestList",requestList);
     }
 
-    @GetMapping("/approval")
-    public String qhApprovalMemberRequests(RequestCodeListForm requestCode){
-        requestService.approvalMember(requestCode.getRequestList());
-        return "";
+    @PostMapping("/approval")
+    public String qhApprovalMemberRequests(RequestCodeListForm requestCodeList){
+        requestService.approvalMember(requestCodeList.getRequestCodeList());
+        return "redirect:request";
     }
 }

--- a/src/main/java/com/donut/prokindonutsweb/controller/member/QhMemberRequestController.java
+++ b/src/main/java/com/donut/prokindonutsweb/controller/member/QhMemberRequestController.java
@@ -1,0 +1,33 @@
+package com.donut.prokindonutsweb.controller.member;
+
+import com.donut.prokindonutsweb.dto.member.MemberRequestDTO;
+import com.donut.prokindonutsweb.dto.member.RequestCodeListForm;
+import com.donut.prokindonutsweb.service.member.MemberRequestService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Collections;
+import java.util.List;
+@Controller
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/qh/member")
+public class QhMemberRequestController {
+    private final MemberRequestService requestService;
+
+    @GetMapping("/request")
+    public void qhGetMemberRequestList(Model model){
+        List<MemberRequestDTO> requestList = requestService.findRequestMember().orElse(Collections.emptyList());
+        model.addAttribute("requestList",requestList);
+    }
+
+    @GetMapping("/approval")
+    public String qhApprovalMemberRequests(RequestCodeListForm requestCode){
+        requestService.approvalMember(requestCode.getRequestList());
+        return "";
+    }
+}

--- a/src/main/java/com/donut/prokindonutsweb/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/donut/prokindonutsweb/dto/member/MemberRequestDTO.java
@@ -31,7 +31,7 @@ public class MemberRequestDTO {
 
     private String address;
 
-    //requestCode 서비스단에서 로직하여 등록처리
+    //requestCode 서비스단에서 로직으로 등록처리
     private String requestCode;
     private String request;
     private String authorityCode;

--- a/src/main/java/com/donut/prokindonutsweb/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/donut/prokindonutsweb/dto/member/MemberRequestDTO.java
@@ -1,0 +1,40 @@
+package com.donut.prokindonutsweb.dto.member;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class MemberRequestDTO {
+
+
+    @NotBlank
+    private String name;
+
+    private String phoneNumber;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String id;
+
+    @NotBlank
+    private String password;
+
+    private String address;
+
+    //requestCode 서비스단에서 로직하여 등록처리
+    private String requestCode;
+    private String request;
+    private String authorityCode;
+    private LocalDate requestDate;
+
+}

--- a/src/main/java/com/donut/prokindonutsweb/dto/member/RequestCodeListForm.java
+++ b/src/main/java/com/donut/prokindonutsweb/dto/member/RequestCodeListForm.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 @Data
 public class RequestCodeListForm {
-    private List<String> requestList;
+    private List<String> requestCodeList;
 }

--- a/src/main/java/com/donut/prokindonutsweb/dto/member/RequestCodeListForm.java
+++ b/src/main/java/com/donut/prokindonutsweb/dto/member/RequestCodeListForm.java
@@ -1,0 +1,10 @@
+package com.donut.prokindonutsweb.dto.member;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class RequestCodeListForm {
+    private List<String> requestList;
+}

--- a/src/main/java/com/donut/prokindonutsweb/mappers/member/MemberRequestMapper.java
+++ b/src/main/java/com/donut/prokindonutsweb/mappers/member/MemberRequestMapper.java
@@ -9,4 +9,5 @@ public interface MemberRequestMapper {
     void approvalMember(String requestCode);
     void deleteRequestMember(String requestCode);
     String requestCode();
+    MemberRequestVO selectByMemberRequest(String requestCode);
 }

--- a/src/main/java/com/donut/prokindonutsweb/mappers/member/MemberRequestMapper.java
+++ b/src/main/java/com/donut/prokindonutsweb/mappers/member/MemberRequestMapper.java
@@ -1,0 +1,12 @@
+package com.donut.prokindonutsweb.mappers.member;
+
+
+import com.donut.prokindonutsweb.vo.member.MemberRequestVO;
+import java.util.List;
+
+public interface MemberRequestMapper {
+    List<MemberRequestVO> selectRequestMember();
+    void approvalMember(String requestCode);
+    void deleteRequestMember(String requestCode);
+    String requestCode();
+}

--- a/src/main/java/com/donut/prokindonutsweb/service/member/MemberRequestService.java
+++ b/src/main/java/com/donut/prokindonutsweb/service/member/MemberRequestService.java
@@ -1,0 +1,13 @@
+package com.donut.prokindonutsweb.service.member;
+
+import com.donut.prokindonutsweb.dto.member.MemberRequestDTO;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberRequestService {
+
+    Optional<List<MemberRequestDTO>> findRequestMember();
+    String memberRequestCode();
+    void approvalMember(List<String> requestCodeList);
+}

--- a/src/main/java/com/donut/prokindonutsweb/service/member/MemberRequestServiceImpl.java
+++ b/src/main/java/com/donut/prokindonutsweb/service/member/MemberRequestServiceImpl.java
@@ -54,10 +54,10 @@ public class MemberRequestServiceImpl implements MemberRequestService {
     public void approvalMember(List<String> requestCodeList) {
         //승인 리스트에서 개별 요청 코드 조회
         requestCodeList.stream().forEach(requestCode -> {
-            //요청 코드에 해당하는 객체의 요청 상태를 "승인"으로 변경
-            requestMapper.approvalMember(requestCode);
             //요청 코드에 해당하는 객체 조회
             MemberRequestVO memberRequestVO = requestMapper.selectByMemberRequest(requestCode);
+            //요청 코드에 해당하는 객체의 요청 상태를 "승인"으로 변경
+            requestMapper.approvalMember(memberRequestVO.getRequest());
             //조회한 요청객체를 회원객체로 mapping
             MemberAccountVO memberAccountVO = MemberAccountVO.builder()
                     .memberCode(memberService.memberCode("FM"))

--- a/src/main/java/com/donut/prokindonutsweb/service/member/MemberRequestServiceImpl.java
+++ b/src/main/java/com/donut/prokindonutsweb/service/member/MemberRequestServiceImpl.java
@@ -1,0 +1,77 @@
+package com.donut.prokindonutsweb.service.member;
+
+import com.donut.prokindonutsweb.dto.member.MemberAccountDTO;
+import com.donut.prokindonutsweb.dto.member.MemberRequestDTO;
+import com.donut.prokindonutsweb.mappers.member.MemberMapper;
+import com.donut.prokindonutsweb.mappers.member.MemberRequestMapper;
+import com.donut.prokindonutsweb.vo.member.MemberAccountVO;
+import com.donut.prokindonutsweb.vo.member.MemberRequestVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class MemberRequestServiceImpl implements MemberRequestService {
+    private final ModelMapper modelMapper;
+    private final MemberRequestMapper requestMapper;
+    private final MemberMapper memberMapper;
+    private final MemberService memberService;
+
+    //회원가입 요청 테이블 전체 조회
+    @Override
+    public Optional<List<MemberRequestDTO>> findRequestMember() {
+        List<MemberRequestVO> memberRequestVOS = requestMapper.selectRequestMember();
+        List<MemberRequestDTO> memberRequestDTOS = memberRequestVOS.stream()
+                .map(memberRequestVO->modelMapper.map(memberRequestVO,MemberRequestDTO.class)).toList();
+        return Optional.ofNullable(memberRequestDTOS.isEmpty()? null : memberRequestDTOS);
+    }
+
+    //회원가입 신청 시 사용 예정
+    @Override
+    public String memberRequestCode() {
+        String memberRequestCode = requestMapper.requestCode();
+        int number = Integer.parseInt(memberRequestCode.replaceAll("\\D", ""));
+        return "RQ"+(number+1);
+    }
+
+
+    /*
+    *회원가입요청 승인
+    *트랜잭션(하나라도 실패시 롤백)
+    *   요청상태를 승인으로 변경
+    *           -> 승인처리된 요청객체를 회원객체로 맵핑
+    *           -> 회원테이들에 삽입
+    *           -> 요청테이블에서 삭제
+    * */
+    @Override
+    @Transactional
+    public void approvalMember(List<String> requestCodeList) {
+        //승인 리스트에서 개별 요청 코드 조회
+        requestCodeList.stream().forEach(requestCode -> {
+            //요청 코드에 해당하는 객체의 요청 상태를 "승인"으로 변경
+            requestMapper.approvalMember(requestCode);
+            //요청 코드에 해당하는 객체 조회
+            MemberRequestVO memberRequestVO = requestMapper.selectByMemberRequest(requestCode);
+            //조회한 요청객체를 회원객체로 mapping
+            MemberAccountVO memberAccountVO = MemberAccountVO.builder()
+                    .memberCode(memberService.memberCode("FM"))
+                    .authorityCode("FM")
+                    .name(memberRequestVO.getName())
+                    .phoneNumber(memberRequestVO.getPhoneNumber())
+                    .address(memberRequestVO.getAddress())
+                    .email(memberRequestVO.getEmail())
+                    .id(memberRequestVO.getId())
+                    .password(memberRequestVO.getPassword()).build();
+           //회원 테이블에 해당 객체 삽입
+            memberMapper.insertMember(memberAccountVO);
+            //요청 테이블에서 해당 객체 삭제
+            requestMapper.deleteRequestMember(requestCode);
+        });
+    }
+}

--- a/src/main/java/com/donut/prokindonutsweb/vo/member/MemberRequestVO.java
+++ b/src/main/java/com/donut/prokindonutsweb/vo/member/MemberRequestVO.java
@@ -1,0 +1,24 @@
+package com.donut.prokindonutsweb.vo.member;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class MemberRequestVO {
+    private String requestCode;
+    private String name;
+    private String phoneNumber;
+    private String email;
+    private String id;
+    private String password;
+    private String address;
+    private String request;
+    private String authorityCode;
+    private LocalDate requestDate;
+
+}

--- a/src/main/resources/mappers/member/MemberRequestMapper.xml
+++ b/src/main/resources/mappers/member/MemberRequestMapper.xml
@@ -30,5 +30,9 @@
     <select id="requestCode" resultType="String">
         Select requestCode From memberrequest  Order by CAST(substring(requestCode, 3) AS UNSIGNED) DESC LIMIT 1;
     </select>
+    
+    <select id="selectByMemberRequest" resultType="MemberRequestVO">
+        select * from memberrequest where requestCode = #{requestCode}
+    </select>
 
 </mapper>

--- a/src/main/resources/mappers/member/MemberRequestMapper.xml
+++ b/src/main/resources/mappers/member/MemberRequestMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.donut.prokindonutsweb.mappers.member.MemberRequestMapper">
+
+    <!--회원가입요청 테이블 조회 -->
+    <select id="selectRequestMember" resultType="MemberRequestVO">
+        select * from memberrequest
+    </select>
+
+
+    <!--회원가입 요청 상태 승인으로 변경 -->
+    <update id="approvalMember">
+            update memberrequest
+            set request = '승인'
+            where requestCode = #{requestCode}
+    </update>
+
+
+    <!--회원가입 요청 삭제-->
+    <delete id="deleteRequestMember" >
+        delete from memberrequest
+        where requestCode = #{requestCode}
+    </delete>
+
+
+    <!--가장 최근 발급한 회원가입 요청 코드 조회 -->
+    <select id="requestCode" resultType="String">
+        Select requestCode From memberrequest  Order by CAST(substring(requestCode, 3) AS UNSIGNED) DESC LIMIT 1;
+    </select>
+
+</mapper>

--- a/src/main/webapp/WEB-INF/views/qh/member/request.jsp
+++ b/src/main/webapp/WEB-INF/views/qh/member/request.jsp
@@ -79,6 +79,7 @@
                                 <tr>
                                     <th><input type="checkbox" id="select-all"></th>
                                     <th>요청 날짜</th>
+                                    <th>요청 코드</th>
                                     <th>성함</th>
                                     <th>전화번호</th>
                                     <th>이메일</th>
@@ -88,7 +89,23 @@
                                     <th>요청상태</th>
                                 </tr>
                                 </thead>
-                                <tbody></tbody>
+                                <tbody>
+
+                                <c:forEach var="request" items="${requestList}">
+                                    <tr>
+                                        <td><input type="checkbox" class="row-checkbox" /></td>
+                                        <td>${request.requestDate}</td>
+                                        <td>${request.requestCode}</td>
+                                        <td>${request.name}</td>
+                                        <td>${request.phoneNumber}</td>
+                                        <td>${request.email}</td>
+                                        <td>${request.address}</td>
+                                        <td>${request.id}</td>
+                                        <td>${request.password}</td>
+                                        <td>${request.request}</td>
+                                    </tr>
+
+                                </c:forEach>
                                 </tbody>
                             </table>
                         </div>
@@ -98,6 +115,7 @@
 
             <!-- Modal HTML Start -->
             <!-- 승인 모달 -->
+            <form id="approvalForm" method="post" action="/qh/member/approval" accept-charset="UTF-8">
             <div class="modal fade" id="approveModal" tabindex="-1" aria-labelledby="approveModalLabel" aria-hidden="true">
                 <div class="modal-dialog modal-dialog-centered">
                     <div class="modal-content">
@@ -107,16 +125,17 @@
                         </div>
                         <div class="modal-body">
                             <h5>선택한 회원의 가입요청을 승인하겠습니까?</h5><br>
-                            <ul id="approveList" class="list-group mb-3">
+                            <ul id="approvalList" class="list-group mb-3">
                                 <!-- 선택된 회원 목록 삽입 -->
                             </ul>
                             <div class="d-flex justify-content-end gap-2">
-                                <button type="button" class="main-btn primary-btn btn-hover text-center" id="confirmApprove">승인</button>
+                                <button type="button" class="main-btn primary-btn btn-hover text-center" id="confirmApproval">승인</button>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
+            </form>
             <!-- Modal HTML End -->
 
         </div>
@@ -165,84 +184,6 @@
             { targets: [1, 2, 3, 4, 6, 7], className: 'text-center' } // JS 속성으로 가운데 정렬
         ],
         order: [[1, 'asc']],
-        ajax: function(data, callback, settings) {
-            const dummyMembers = [
-                {
-                    requestDate: "2025-03-15",
-                    name: "김주현",
-                    phone: "010-3498-1265",
-                    email: "juhyun_kim@gmail.com",
-                    address: "서울특별시 동작구 사당로 22",
-                    id: "juhyun01",
-                    password: "juhyun01!",
-                    status: "승인대기"
-                },
-                {
-                    requestDate: "2025-03-27",
-                    name: "이채원",
-                    phone: "010-8217-9033",
-                    email: "chae_lee@gmail.com",
-                    address: "경기도 고양시 일산동구 중앙로 88",
-                    id: "cwlee99",
-                    password: "cwlee99!",
-                    status: "승인대기"
-                },
-                {
-                    requestDate: "2025-03-30",
-                    name: "박상우",
-                    phone: "010-4726-8859",
-                    email: "sangwoo_p@gmail.com",
-                    address: "인천광역시 연수구 센트럴로 11",
-                    id: "psw321",
-                    password: "psw321!",
-                    status: "승인대기"
-                },
-                {
-                    requestDate: "2025-04-02",
-                    name: "정예린",
-                    phone: "010-6325-7104",
-                    email: "yerin_j@gmail.com",
-                    address: "대전광역시 유성구 유성대로 135",
-                    id: "yerin333",
-                    password: "yerin333!",
-                    status: "승인대기"
-                },
-                {
-                    requestDate: "2025-04-04",
-                    name: "오태경",
-                    phone: "010-2951-4480",
-                    email: "taek_oh@naver.com",
-                    address: "부산광역시 해운대구 마린시티2로 77",
-                    id: "otk_84",
-                    password: "otk_84!",
-                    status: "승인대기"
-                }
-            ];
-
-            // 데이터를 비동기적으로 불러온 후 callback으로 전달
-            // 페이지네이션을 위해 반드시 필요 (단, 본인 더미데이터 변수로 변경 필요)
-            Promise.resolve().then(() => {
-                callback({ data: dummyMembers });
-            });
-        },
-        columns: [
-            { // 체크박스 컬럼
-                data: null,
-                orderable: false,
-                searchable: false,
-                render: function(data, type, row, meta) {
-                    return '<input type="checkbox" class="row-checkbox">';
-                }
-            },
-            { data: 'requestDate', title: '요청날짜' },
-            { data: 'name', title: '성함' },
-            { data: 'phone', title: '전화번호' },
-            { data: 'email', title: '이메일' },
-            { data: 'address', title: '주소' },
-            { data: 'id', title: '아이디' },
-            { data: 'password', title: '비밀번호' },
-            { data: 'status', title: '요청상태' },
-        ],
         paging: true,
         pageLength: 10,
         lengthMenu: [[5, 10, 20, -1], ['5개', '10개', '20개', '전체']],
@@ -349,14 +290,17 @@
 
     // 승인 버튼 클릭 시
     $('#btnApprove_clone').on('click', function (e) {
-        const selectedRows = table.rows({ page: 'current' }).nodes();
         const selectedData = [];
 
-        $(selectedRows).each(function () {
-            if ($(this).find('.row-checkbox').prop('checked')) {
-                const data = table.row(this).data();
-                selectedData.push(data);
-            }
+        $('#datatable tbody input.row-checkbox:checked').each(function () {
+            const $tr = $(this).closest('tr');
+            const rowData = {
+                id: $tr.find('td').eq(7).text().trim(),      // 아이디
+                name: $tr.find('td').eq(3).text().trim(),    // 성함
+                requestCode: $tr.find('td').eq(2).text().trim(),  // 요청 코드
+                request: $tr.find('td').eq(9).text().trim()  // 요청 상태
+            };
+            selectedData.push(rowData);
         });
 
         if (selectedData.length === 0) {
@@ -365,25 +309,42 @@
         }
 
         // 회원 목록을 <ul> 안에 추가
-        const $list = $('#approveList');
+        const $list = $('#approvalList');
         $list.empty(); // 기존 내용 비우고
 
         selectedData.forEach((item) => {
-            const $li = $(`
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <span>${item.name} (${item.id})</span>
-        <span class="badge bg-secondary">${item.status}</span>
+            const li = `
+      <li class="list-group-item d-flex justify-content-between align-items-center" data-request-code="`+ item.requestCode +`">
+        <span>` + item.name + ` (` + item.id + `)</span>
+        <span class="badge bg-secondary">` + item.request + `</span>
       </li>
-    `);
-            $list.append($li);
+    `;
+            $list.append(li);
         });
         $('#approveModal').modal('show');
     });
+
+
+    // 승인 확인 버튼 클릭 시: form에 hidden input 추가하고 전송
+    $('#confirmApproval').on('click', function (e) {
+        const $form = $('#approvalForm');
+
+        // 혹시 이전에 추가된 hidden input이 있으면 제거
+        $form.find('input[name="requestCodeList"]').remove();
+
+        $('#approvalList .list-group-item').each(function () {
+            const requestCode = $(this).data('request-code');
+            const input = `<input type="hidden" name="requestCodeList" value="` + requestCode + `" />`;
+            $form.append(input);
+        });
+
+        $form.submit(); // form 전송
+    });
+
 
     //mypageData
     <%@ include file="/WEB-INF/views/includes/mypage/mypageData.jsp" %>
 
 </script>
-
 </body>
 </html>

--- a/src/test/java/com/donut/prokindonutsweb/controller/member/QhMemberRequestControllerTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/controller/member/QhMemberRequestControllerTest.java
@@ -1,0 +1,48 @@
+package com.donut.prokindonutsweb.controller.member;
+
+import com.donut.prokindonutsweb.dto.member.MemberRequestDTO;
+import com.donut.prokindonutsweb.dto.member.RequestCodeListForm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+@Log4j2
+@ExtendWith(SpringExtension.class)
+@RequiredArgsConstructor
+@ContextConfiguration(locations = "file:src/main/webapp/WEB-INF/spring/root-context.xml")
+class QhMemberRequestControllerTest {
+    @Autowired
+    private QhMemberRequestController requestController;
+
+    @Test
+    @DisplayName("qh 회원요청 목록 Model 바인딩 테스트")
+    void qhGetMemberRequestList() {
+        Model model = new ExtendedModelMap();
+        requestController.qhGetMemberRequestList(model);
+        List<MemberRequestDTO> memberRequestDTOList
+                = (List<MemberRequestDTO>)model.getAttribute("requestList");
+        assertNotNull(memberRequestDTOList);
+        memberRequestDTOList.forEach(log::info);
+
+    }
+
+    @Test
+    @DisplayName("회원가입 요청 승인 controller 반영 테스트")
+    void qhApprovalMemberRequests() {
+        RequestCodeListForm requestCodeListForm = new RequestCodeListForm();
+        requestCodeListForm.setRequestList(List.of("RQ06","RQ07","RQ08"));
+        requestController.qhApprovalMemberRequests(requestCodeListForm);
+    }
+}

--- a/src/test/java/com/donut/prokindonutsweb/controller/member/QhMemberRequestControllerTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/controller/member/QhMemberRequestControllerTest.java
@@ -42,7 +42,7 @@ class QhMemberRequestControllerTest {
     @DisplayName("회원가입 요청 승인 controller 반영 테스트")
     void qhApprovalMemberRequests() {
         RequestCodeListForm requestCodeListForm = new RequestCodeListForm();
-        requestCodeListForm.setRequestList(List.of("RQ06","RQ07","RQ08"));
+        requestCodeListForm.setRequestCodeList(List.of("RQ06","RQ07","RQ08"));
         requestController.qhApprovalMemberRequests(requestCodeListForm);
     }
 }

--- a/src/test/java/com/donut/prokindonutsweb/mappers/member/MemberMapperTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/mappers/member/MemberMapperTest.java
@@ -74,7 +74,7 @@ class MemberMapperTest {
     }
 
     @Test
-    @DisplayName("DB의 가장 높은 수의 코드 select 테스트")
+    @DisplayName("DB의 가장 높은 수의 회원 코드 select 테스트")
     void memberCode() {
         String maxRequestCode = mapper.memberCode();
         assertEquals("QH100", maxRequestCode);

--- a/src/test/java/com/donut/prokindonutsweb/mappers/member/MemberMapperTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/mappers/member/MemberMapperTest.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 @Log4j2
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations="file:src/main/webapp/WEB-INF/spring/root-context.xml")
@@ -27,7 +29,7 @@ class MemberMapperTest {
     //loadMember MapperTest
     @Test
     @DisplayName("DB의 전체 회원조회 테스트")
-    public void loadMember(){
+    public void selectMember(){
         List<MemberAccountVO> memberList = mapper.selectMember();
         memberList.forEach(log::info);
     }
@@ -69,5 +71,13 @@ class MemberMapperTest {
     public void deleteMember(){
         List<String> memberCodeList = new ArrayList<>(Arrays.asList("QH100"));
         mapper.deleteMember(memberCodeList);
+    }
+
+    @Test
+    @DisplayName("DB의 가장 높은 수의 코드 select 테스트")
+    void memberCode() {
+        String maxRequestCode = mapper.memberCode();
+        assertEquals("QH100", maxRequestCode);
+        log.info(maxRequestCode);
     }
 }

--- a/src/test/java/com/donut/prokindonutsweb/mappers/member/MemberRequestMapperTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/mappers/member/MemberRequestMapperTest.java
@@ -1,0 +1,51 @@
+package com.donut.prokindonutsweb.mappers.member;
+
+import com.donut.prokindonutsweb.vo.member.MemberRequestVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Log4j2
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations="file:src/main/webapp/WEB-INF/spring/root-context.xml")
+@RequiredArgsConstructor
+class MemberRequestMapperTest {
+
+    @Autowired
+    private MemberRequestMapper mapper;
+
+    @Test
+    @DisplayName("DB의 전체 회원가입요청 조회 테스트")
+    void selectRequestMember() {
+        List<MemberRequestVO> memberList = mapper.selectRequestMember();
+        memberList.forEach(log::info);
+    }
+
+    @Test
+    @DisplayName("회원 가입요청상태 승인 DB 반영 테스트 ")
+    void approvalMember() {
+        mapper.approvalMember("RQ06");
+      }
+
+    @Test
+    @DisplayName("회원 삭제 DB 반영 테스트")
+    void deleteRequestMember() {
+        mapper.deleteRequestMember("RQ06");
+    }
+
+    @Test
+    void requestCode() {
+        String maxRequestCode = mapper.requestCode();
+        assertEquals("RQ06", maxRequestCode);
+        log.info(maxRequestCode);
+    }
+}

--- a/src/test/java/com/donut/prokindonutsweb/mappers/member/MemberRequestMapperTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/mappers/member/MemberRequestMapperTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Log4j2
 @ExtendWith(SpringExtension.class)
@@ -37,15 +38,24 @@ class MemberRequestMapperTest {
       }
 
     @Test
-    @DisplayName("회원 삭제 DB 반영 테스트")
+    @DisplayName("회원 가입요청 삭제 DB 반영 테스트")
     void deleteRequestMember() {
         mapper.deleteRequestMember("RQ06");
     }
 
     @Test
+    @DisplayName("DB의 가장 높은 수의 가입요청코드 select 테스트")
     void requestCode() {
         String maxRequestCode = mapper.requestCode();
         assertEquals("RQ06", maxRequestCode);
         log.info(maxRequestCode);
+    }
+
+    @Test
+    @DisplayName("회원가입 요청 코드로 객체 조회 테스트")
+    public void selectByMemberRequest(){
+        MemberRequestVO memberRequestVO = mapper.selectByMemberRequest("RQ06");
+        assertNotNull(memberRequestVO);
+        log.info(memberRequestVO);
     }
 }

--- a/src/test/java/com/donut/prokindonutsweb/service/member/MemberRequestServiceImplTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/service/member/MemberRequestServiceImplTest.java
@@ -1,0 +1,49 @@
+package com.donut.prokindonutsweb.service.member;
+
+import com.donut.prokindonutsweb.dto.member.MemberRequestDTO;
+import com.donut.prokindonutsweb.vo.member.MemberRequestVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.test.util.AssertionErrors.assertNotNull;
+
+@Log4j2
+@ExtendWith(SpringExtension.class)
+@RequiredArgsConstructor
+@ContextConfiguration(locations="file:src/main/webapp/WEB-INF/spring/root-context.xml")
+class MemberRequestServiceImplTest {
+    @Autowired
+    private MemberRequestService requestService;
+
+    @Test
+    @DisplayName("Service 회원가입 요청 조회 테스트")
+    void findRequestMember() {
+        List<MemberRequestDTO> list = requestService.findRequestMember().get();
+        assertNotNull("List 정상 조회 ",list);
+        list.forEach(log::info);
+    }
+
+    @Test
+    @DisplayName("Service 회원가입 요청 코드 생성 테스트")
+    void memberRequestCode() {
+        String requestCode = requestService.memberRequestCode();
+        log.info(requestCode);
+    }
+
+    @Test
+    @DisplayName("Service 회원가입 요청 승인 테스트")
+    void approvalMember() {
+        List<String> approvalList = new ArrayList<>(Arrays.asList("RQ06","RQ07","RQ08"));
+        requestService.approvalMember(approvalList);
+    }
+}

--- a/src/test/java/com/donut/prokindonutsweb/service/member/MemberServiceImplTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/service/member/MemberServiceImplTest.java
@@ -1,7 +1,6 @@
 package com.donut.prokindonutsweb.service.member;
 
 import com.donut.prokindonutsweb.dto.member.MemberAccountDTO;
-import com.donut.prokindonutsweb.vo.member.MemberAccountVO;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,6 +71,17 @@ class MemberServiceImplTest {
     public void deleteMember(){
         List<String> memberCodeList = new ArrayList<>(Arrays.asList("QH100"));
         memberService.deleteMember(memberCodeList);
+    }
+
+    @Test
+    @DisplayName("Service 회원 코드 생성 테스트")
+    public void memberCode(){
+        String qhMemberCode = memberService.memberCode("QH");
+        String wmMemberCode = memberService.memberCode("WM");
+        String fmMemberCode = memberService.memberCode("FM");
+        log.info("qhMemberCode = " + qhMemberCode +
+                "| wmMemberCode = " + wmMemberCode +
+                "| fmMemberCode = " + fmMemberCode);
     }
 
 }

--- a/src/test/resources/mybatis-config.xml
+++ b/src/test/resources/mybatis-config.xml
@@ -4,7 +4,10 @@
         "https://mybatis.org/dtd/mybatis-3-config.dtd">
 <configuration>
     <typeAliases>
+        <typeAlias alias="MemberRequestVO" type="com.donut.prokindonutsweb.vo.member.MemberRequestVO"/>
         <typeAlias alias="MemberAccountVO" type="com.donut.prokindonutsweb.vo.member.MemberAccountVO"/>
+        <typeAlias alias="MemberAccountDTO" type="com.donut.prokindonutsweb.dto.member.MemberAccountDTO"/>
+        <typeAlias alias="MemberRequestDTO" type="com.donut.prokindonutsweb.dto.member.MemberRequestDTO"/>
         <typeAlias alias="WarehouseDTO" type="com.donut.prokindonutsweb.dto.warehouse.WarehouseDTO"/>
         <typeAlias alias="WarehouseUpdateDTO" type="com.donut.prokindonutsweb.dto.warehouse.WarehouseUpdateDTO"/>
         <typeAlias alias="WarehouseDeleteDTO" type="com.donut.prokindonutsweb.dto.warehouse.WarehouseDeleteDTO"/>


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- 관련된 이슈 번호를 작성해주세요. 예: #45 -->
#39

---

## 📝 요약 (Summary)

- 본사관리자가 회원가입 요청을 조회하고 승인할 수 있는 기능을 구현.  
- 요청 승인 시, 요청 상태 변경 → 회원 테이블 등록 → 요청 테이블 삭제 순으로 진행
- 트랜잭션을 적용해 하나라도 실패하면 전체 작업이 롤백되도록 처리함.

---

## 🛠️ 작업 내용

- [x] 본사관리자 회원가입요청 목록 조회 기능 구현
- [x] 회원가입 요청 승인 기능 구현
- [x] 승인 시 `승인 → 회원 테이블 등록 → 요청 삭제` 단계별 트랜잭션 적용
- [x] MemberRequestServiceImpl 테스트 작성 및 바인딩 검증
- [ ] 트랜잭션 단위 테스트 : 예정

---

## ✅ PR 체크리스트

- [x] 커밋 메시지를 컨벤션에 맞게 작성했나요?
- [x] 로컬에서 테스트를 완료했나요?
- [x] 코드 스타일 가이드를 따랐나요?
