### PR TITLE
Fix/login

### DIFF
--- a/src/main/java/com/donut/prokindonutsweb/member/controller/MyPageController.java
+++ b/src/main/java/com/donut/prokindonutsweb/member/controller/MyPageController.java
@@ -45,7 +45,7 @@ public class MyPageController {
     // 탈퇴
     @PostMapping("/delete")
     public String secession( @AuthenticationPrincipal CustomUserDetails user, HttpSession session) {
-        memberService.deleteByMember(user.getUsername());
+        memberService.deleteByMember(user.getId());
         //세션 무효화
         session.invalidate();
         // 인증정보 제거

--- a/src/main/java/com/donut/prokindonutsweb/member/controller/MyPageController.java
+++ b/src/main/java/com/donut/prokindonutsweb/member/controller/MyPageController.java
@@ -9,14 +9,13 @@ import com.donut.prokindonutsweb.security.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
 
@@ -37,10 +36,20 @@ public class MyPageController {
 
     // 수정
     @PostMapping("/update")
-    public String update(@ModelAttribute MemberAccountDTO formData) {
-        memberService.updateByMember(formData);
-        return "redirect:/mypage";
+    @ResponseBody
+    public ResponseEntity<String> update(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @ModelAttribute MemberAccountDTO formData
+    ) {
+        try {
+            memberService.updateByMember(user.getId(), formData);
+            return ResponseEntity.ok("수정 완료");
+        } catch (Exception e) {
+            log.error("❌ 수정 중 에러 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 오류 발생");
+        }
     }
+
 
     // 탈퇴
     @PostMapping("/delete")

--- a/src/main/java/com/donut/prokindonutsweb/member/controller/QhMemberController.java
+++ b/src/main/java/com/donut/prokindonutsweb/member/controller/QhMemberController.java
@@ -7,6 +7,7 @@ import com.donut.prokindonutsweb.member.service.MemberRequestService;
 import com.donut.prokindonutsweb.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -64,18 +65,20 @@ public class QhMemberController {
 
 
     @PostMapping("/update")
-    public String qhUpdateMembers(@Valid @ModelAttribute("memberList")  MemberListForm memberlist,
-                                  BindingResult bindingResult, RedirectAttributes redirectAttributes) {
-            if (bindingResult.hasErrors()) {
-                String errorMessage = bindingResult.getAllErrors().get(0).getDefaultMessage();
-                redirectAttributes.addFlashAttribute("errorMessage", errorMessage);
-                redirectAttributes.addFlashAttribute("memberList", memberlist.getMemberList());
-                return "redirect:list";
-            }
+    @ResponseBody
+    public ResponseEntity<String> qhUpdateMembers(@RequestBody MemberListForm memberListForm) {
 
-            memberService.updateMember(memberlist.getMemberList());
-        return "redirect:list";
+        List<MemberAccountDTO> memberList = memberListForm.getMemberList();
+
+        if (memberList == null || memberList.isEmpty()) {
+            return ResponseEntity.badRequest().body("수정할 데이터가 없습니다.");
+        }
+
+        memberService.updateMember(memberList);
+
+        return ResponseEntity.ok("수정 완료");
     }
+
 
     @PostMapping("/delete")
     public String qhDeleteMembers( MemberCodeListForm memberCode) {

--- a/src/main/java/com/donut/prokindonutsweb/member/mapper/MemberMapper.java
+++ b/src/main/java/com/donut/prokindonutsweb/member/mapper/MemberMapper.java
@@ -10,6 +10,7 @@ public interface MemberMapper{
     List<MemberAccountVO> selectMember();
     void insertMember(MemberAccountVO memberVO);
     void updateMember(MemberAccountVO memberVO);
+    void updateMemberById(MemberAccountVO memberVO);
     void deleteMember(@Param("list") List<String> memberList);
     String memberCode();
     int memberIdCheck(String id);

--- a/src/main/java/com/donut/prokindonutsweb/member/service/MemberService.java
+++ b/src/main/java/com/donut/prokindonutsweb/member/service/MemberService.java
@@ -14,7 +14,7 @@ public interface MemberService {
     int memberIdCheck(String id);
 
     int  memberEmailCheck(String email);
-    void updateByMember(MemberAccountDTO dto);
+    void updateByMember(String userid, MemberAccountDTO dto);
     void deleteByMember(String id);
 
 }

--- a/src/main/java/com/donut/prokindonutsweb/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/donut/prokindonutsweb/member/service/MemberServiceImpl.java
@@ -45,6 +45,11 @@ public class MemberServiceImpl implements MemberService {
                 .map(member -> modelMapper.map(member,MemberAccountVO.class)).toList();
         for (MemberAccountVO member : memberVOList) {
             memberMapper.updateMember(member);
+            //멤버 권한 변경시 멤버 코드 재발급하여 재 수정
+            if (!member.getAuthorityCode().equals(member.getMemberCode().substring(0, 2))) {
+                member.setMemberCode(memberCode(member.getAuthorityCode()));
+                memberMapper.updateMemberById(member);
+            }
         }
     }
 

--- a/src/main/java/com/donut/prokindonutsweb/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/donut/prokindonutsweb/member/service/MemberServiceImpl.java
@@ -71,9 +71,12 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void updateByMember(MemberAccountDTO dto){
-        MemberAccountVO memberAccountVO = modelMapper.map(dto,MemberAccountVO.class);
-        memberMapper.updateMember(memberAccountVO);
+    public void updateByMember(String userid ,MemberAccountDTO dto){
+        MemberAccountVO updateMember = modelMapper.map(dto,MemberAccountVO.class);
+        MemberAccountVO uservo = findMapper.searchId(userid);
+        updateMember.setMemberCode(uservo.getMemberCode());
+        updateMember.setAuthorityCode(uservo.getAuthorityCode());
+        memberMapper.updateMember(updateMember);
     }
 
     @Override

--- a/src/main/resources/mappers/member/MemberMapper.xml
+++ b/src/main/resources/mappers/member/MemberMapper.xml
@@ -26,6 +26,17 @@
             where memberCode = #{memberCode}
     </update>
 
+    <update id="updateMemberById" >
+        update memberaccount
+        set authorityCode = #{authorityCode},
+            name = #{name},
+            phoneNumber = #{phoneNumber},
+            email = #{email},
+            address = #{address},
+            id = #{id},
+            password = #{password}
+        where memberCode = #{id}
+    </update>
 
     <delete id="deleteMember" parameterType="list">
         delete from memberaccount

--- a/src/main/webapp/WEB-INF/spring/security-context.xml
+++ b/src/main/webapp/WEB-INF/spring/security-context.xml
@@ -23,14 +23,14 @@
         <intercept-url pattern="/home/login?error"  access="permitAll"/>
 
         <!-- 2) 나머지 공개 경로 -->
-        <intercept-url pattern="/home/signup"         access="permitAll"/>
-        <intercept-url pattern="/home/findId"         access="permitAll"/>
-        <intercept-url pattern="/home/sendCode"       access="permitAll"/>
-        <intercept-url pattern="/home/findPassword"   access="permitAll"/>
-        <intercept-url pattern="/home/idCheck"        access="permitAll"/>
-        <intercept-url pattern="/home/emailCheck"     access="permitAll"/>
-        <intercept-url pattern="/home/resultId"       access="permitAll"/>
-        <intercept-url pattern="/home/resultPassword" access="permitAll"/>
+        <intercept-url pattern="/home/signup"         access="isAnonymous"/>
+        <intercept-url pattern="/home/findId"         access="isAnonymous"/>
+        <intercept-url pattern="/home/sendCode"       access="isAnonymous"/>
+        <intercept-url pattern="/home/findPassword"   access="isAnonymous"/>
+        <intercept-url pattern="/home/idCheck"        access="isAnonymous"/>
+        <intercept-url pattern="/home/emailCheck"     access="isAnonymous"/>
+        <intercept-url pattern="/home/resultId"       access="isAnonymous"/>
+        <intercept-url pattern="/home/resultPassword" access="isAnonymous"/>
         <intercept-url pattern="/resources/**"        access="permitAll"/>
 
         <!-- 3) 권한별 접근 제어 -->

--- a/src/main/webapp/WEB-INF/spring/security-context.xml
+++ b/src/main/webapp/WEB-INF/spring/security-context.xml
@@ -19,7 +19,7 @@
         <csrf disabled="true"/>
 
         <!-- 1) 로그인 폼·처리 URL 공개 -->
-        <intercept-url pattern="/home/login"        access="permitAll"/>
+        <intercept-url pattern="/home/login"        access="isAnonymous()"/>
         <intercept-url pattern="/home/login?error"  access="permitAll"/>
 
         <!-- 2) 나머지 공개 경로 -->

--- a/src/main/webapp/WEB-INF/views/home/findId.jsp
+++ b/src/main/webapp/WEB-INF/views/home/findId.jsp
@@ -260,10 +260,24 @@
                 const id = await res.text();
 
                 if (id && id !== "false") {
-                    alert("찾으시는 아이디 : " + id);
+                    // 1. 복사
+                    try {
+                        await navigator.clipboard.writeText(id);
+                        alert("찾으신 아이디가 클립보드에 복사되었습니다 \n" + id);
+                    } catch (e) {
+                        console.error('복사 실패', e);
+                        alert("아이디: " + id + "\n(※ 복사는 실패했습니다. 직접 복사해주세요.)");
+                    }
+
+                    // 2. 이동 확인
+                    const confirmed = confirm("로그인 페이지로 이동하시겠습니까?");
+                    if (confirmed) {
+                        window.location.href = "${pageContext.request.contextPath}/home/login";
+                    }
                 } else {
                     alert("유효한 인증번호가 아닙니다. 다시 입력해주세요. \n (발급받은 인증번호는 10분동안만 유효합니다.)");
                 }
+
             } catch (error) {
                 alert("서버 요청 중 오류가 발생했습니다.");
             }

--- a/src/main/webapp/WEB-INF/views/home/findPassword.jsp
+++ b/src/main/webapp/WEB-INF/views/home/findPassword.jsp
@@ -270,17 +270,36 @@
 
             const contextPath = "${pageContext.request.contextPath}";
             try {
-                const res = await fetch(contextPath + "/home/resultPassword?email=" + encodeURIComponent(email) + "&inputCode=" + encodeURIComponent(code) + "&id=" + encodeURIComponent(id));
-                const result = await res.text();
-                const password = result.trim();
+                const contextPath = "${pageContext.request.contextPath}";
+                try {
+                    const res = await fetch(contextPath + "/home/resultPassword?email=" + encodeURIComponent(email) + "&inputCode=" + encodeURIComponent(code) + "&id=" + encodeURIComponent(id));
+                    const result = await res.text();
+                    const password = result.trim();
 
-                if (result === "IdCheck") {
-                    alert("아이디가 일치하지 않습니다.");
-                } else if (password && password !== "false") {
-                    alert("찾으시는 비밀번호 : " + password);
-                } else {
-                    alert("유효한 인증번호가 아닙니다. 다시 입력해주세요. \n (발급받은 인증번호는 10분동안만 유효합니다.)");
+                    if (result === "IdCheck") {
+                        alert("아이디가 일치하지 않습니다.");
+                    } else if (password && password !== "false") {
+                        // 비밀번호 클립보드 복사
+                        try {
+                            await navigator.clipboard.writeText(password);
+                            alert("찾으신 비밀번호가 클립보드에 복사되었습니다 \n" + password);
+                        } catch (e) {
+                            console.error('복사 실패', e);
+                            alert("아이디: " + password + "\n(※ 복사는 실패했습니다. 직접 복사해주세요.)");
+                        }
+
+                        // 2. 이동 확인
+                        const confirmed = confirm("로그인 페이지로 이동하시겠습니까?");
+                        if (confirmed) {
+                            window.location.href = "${pageContext.request.contextPath}/home/login";
+                        }
+                    } else {
+                        alert("유효한 인증번호가 아닙니다. 다시 입력해주세요.\n(발급받은 인증번호는 10분 동안만 유효합니다.)");
+                    }
+                } catch (error) {
+                    alert("서버 요청 중 오류가 발생했습니다.");
                 }
+
             } catch (error) {
                 alert("서버 요청 중 오류가 발생했습니다.");
             }

--- a/src/main/webapp/WEB-INF/views/home/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/home/signup.jsp
@@ -310,19 +310,15 @@
                 return;
             }
 
-            //signup 클릭 시 confirm
-            $('#memberRequestForm').on('click', function (e) {
+            const result = confirm('입력하신 정보로 회원가입 요청을 하시겠습니까?');
+            if (!result) {
+                console.log('회원가입 요청 취소');
+                return;
+            }
 
-                const result = confirm('입력하신 정보로 회원가입 요청을 하시겠습니까?');
-                if (!result) {
-                    console.log('회원가입 요청 취소');
-                    return;
-                }
+            console.log('회원가입 요청');
+            $("#memberRequestForm").submit();
 
-                console.log('회원가입 요청');
-                $("#memberRequestForm").submit();
-
-            });
         });
     });
 

--- a/src/main/webapp/WEB-INF/views/includes/mypage/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/mypage/mypage.jsp
@@ -19,8 +19,17 @@
                     </div>
                     <div class="mb-3">
                         <label class="form-label">비밀번호</label>
-                        <input type="password" class="form-control" name="password" id="password" value="${member.password}"/>
+                        <div class="input-group">
+                            <input type="password" class="form-control" id="mypagePassword" name="password" value="${member.password}">
+                            <button type="button" class="btn btn-outline-secondary" id="togglePassword">
+                                <svg id="passwordIcon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
+                                    <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+                                    <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8m8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"/>
+                                </svg>
+                            </button>
+                        </div>
                     </div>
+
                     <div class="mb-3">
                         <label class="form-label">이름</label>
                         <input type="text" class="form-control" name="name" id="name" value="${member.name}"/>

--- a/src/main/webapp/WEB-INF/views/includes/mypage/mypageData.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/mypage/mypageData.jsp
@@ -44,13 +44,4 @@ return;
             }
         });
 
-        // world map 초기화
-        const mapEl = document.getElementById('world-map');
-        if (mapEl) {
-            new jvm.WorldMap({
-                container: mapEl,
-                map: 'world_mill',
-                // …옵션
-            });
-        }
     });

--- a/src/main/webapp/WEB-INF/views/includes/mypage/mypageData.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/mypage/mypageData.jsp
@@ -1,9 +1,34 @@
+$('#togglePassword').on('click', function() {
+const $passwordInput = $('#mypagePassword');
+const $icon = $('#passwordIcon');
+const type = $passwordInput.attr('type') === 'password' ? 'text' : 'password';
+$passwordInput.attr('type', type);
+
+if (type === 'text') {
+$icon.replaceWith(`
+<svg id="passwordIcon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash-fill" viewBox="0 0 16 16">
+    <path d="m10.79 12.912-1.614-1.615a3.5 3.5 0 0 1-4.474-4.474l-2.06-2.06C.938 6.278 0 8 0 8s3 5.5 8 5.5a7 7 0 0 0 2.79-.588M5.21 3.088A7 7 0 0 1 8 2.5c5 0 8 5.5 8 5.5s-.939 1.721-2.641 3.238l-2.062-2.062a3.5 3.5 0 0 0-4.474-4.474z"/>
+    <path d="M5.525 7.646a2.5 2.5 0 0 0 2.829 2.829zm4.95.708-2.829-2.83a2.5 2.5 0 0 1 2.829 2.829zm3.171 6-12-12 .708-.708 12 12z"/>
+</svg>
+`);
+} else {
+$icon.replaceWith(`
+<svg id="passwordIcon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
+    <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+    <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8m8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7"/>
+</svg>
+`);
+}
+});
+
+
+
 $('#btnUpdate').on('click', async function (e) {
 e.preventDefault();
 
 const data = {
 id: $('#id').val().trim(),
-password: $('#password').val().trim(),
+password: $('#mypagePassword').val().trim(),
 name: $('#name').val().trim(),
 email: $('#email').val().trim(),
 phoneNumber: $('#phoneNumber').val().trim(),

--- a/src/main/webapp/WEB-INF/views/includes/mypage/mypageData.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/mypage/mypageData.jsp
@@ -1,47 +1,47 @@
+$('#btnUpdate').on('click', async function (e) {
+e.preventDefault();
 
-    $(function(){
+const data = {
+id: $('#id').val().trim(),
+password: $('#password').val().trim(),
+name: $('#name').val().trim(),
+email: $('#email').val().trim(),
+phoneNumber: $('#phoneNumber').val().trim(),
+address: $('#address').val().trim()
+};
 
-        // 수정 버튼 클릭 (async 중요!)
-        $('#btnUpdate').on('click', async function(e){
-            e.preventDefault();
-
-            // 1) 필드값 가져오기 & 기본 검증…
-            const password      = $('#password').val().trim();
-            const name          = $('#name').val().trim();
-            const email         = $('#email').val().trim();
-            const phoneNumber   = $('#phoneNumber').val().trim();
-
-
-            if (!/^[A-Za-z가-힣]{1,10}$/.test(name)) {
-                alert("이름은 한글/영어 조합, 최대 10글자입니다.");
-                return;
-            }
-            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-                alert("올바른 이메일 형식을 입력해주세요.");
-                return;
-            }
-
-            // 3) 전화번호 검증 (선택)
-            if (phoneNumber && !/^[0-9]{10,11}$/.test(phoneNumber)) {
-                alert("전화번호는 10~11자리 숫자입니다.");
-                return;
-            }
-const result = confirm('입력하신 정보로 수정 하시겠습니까?');
-if (!result) {
-console.log('수정 취소');
+if (!/^[A-Za-z가-힣]{1,10}$/.test(data.name)) {
+alert("이름은 한글/영어 조합, 최대 10글자입니다.");
 return;
 }
-            // 4) 모두 통과하면 실제 폼 전송
-            $('#mypageForm').submit();
-        });
+if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+alert("올바른 이메일 형식을 입력해주세요.");
+return;
+}
+if (data.phoneNumber && !/^[0-9]{10,11}$/.test(data.phoneNumber)) {
+alert("전화번호는 10~11자리 숫자입니다.");
+return;
+}
 
-        // 탈퇴 버튼
-        $('#bntMypageSecession').on('click', function(e){
-            e.preventDefault();
-            if (confirm('⚠️ 계정을 삭제하시겠습니까?\n삭제된 계정은 복구되지 않습니다.')) {
-                $('#mypageModal').modal('hide');
-                $('#secessionForm').submit();
-            }
-        });
+if (!confirm("입력하신 정보로 수정하시겠습니까?")) return;
 
-    });
+try {
+const res = await fetch('/mypage/update', {
+method: 'POST',
+headers: {
+'Content-Type': 'application/x-www-form-urlencoded'
+},
+body: new URLSearchParams(data)  // ✅ form처럼 보내짐
+});
+
+if (res.ok) {
+alert("수정 완료되었습니다.");
+// 모달 유지됨
+} else {
+alert("수정 중 오류 발생");
+}
+} catch (err) {
+console.error("요청 실패", err);
+alert("서버와 연결 실패");
+}
+});

--- a/src/main/webapp/WEB-INF/views/qh/member/list.jsp
+++ b/src/main/webapp/WEB-INF/views/qh/member/list.jsp
@@ -635,7 +635,7 @@
                     email: $tr.find('td').eq(4).text().trim(),
                     address: $tr.find('td').eq(5).text().trim(),
                     id: $tr.find('td').eq(6).text().trim(),
-                    password: $tr.data('password') // 🔥 여기!
+                    password: $tr.data('password') // 여기!
                 };
                 selectedData.push(rowData);
             });
@@ -646,21 +646,24 @@
             selectedData.forEach((item, index) => {
                 const rowHtml = `
 <tr>
-    <td><select class="form-select" name="memberList[` + index + `].authorityCode">
-        <option value="QH">본사관리자</option>
-        <option value="WM">창고관리자</option>
-        <option value="FM">가맹점주</option>
-    </select></td>
+    <td>
+        <select class="form-select" name="memberList[` + index + `].authorityCode">
+            <option value="QH">본사관리자</option>
+            <option value="WM">창고관리자</option>
+            <option value="FM">가맹점주</option>
+        </select>
+    </td>
     <td><input type="text" name="memberList[` + index + `].name" class="form-control" value="` + item.name + `" /></td>
     <td><input type="text" name="memberList[` + index + `].email" class="form-control" value="` + item.email + `" data-original-email="` + item.email + `" /></td>
     <td><input type="text" name="memberList[` + index + `].phoneNumber" class="form-control" value="` + item.phoneNumber + `" /></td>
     <td><input type="text" name="memberList[` + index + `].address" class="form-control" value="` + item.address + `" /></td>
-    <td><input type="text" name="memberList[` + index + `].id" class="form-control" value="` + item.id + `" readonly /></td>
+    <td>
+        <input type="text" name="memberList[` + index + `].id" class="form-control" value="` + item.id + `" readonly />
+        <input type="hidden" name="memberList[` + index + `].memberCode" value="` + item.memberCode + `" />
+        <input type="hidden" name="memberList[` + index + `].password" value="` + item.password + `" />
+    </td>
 </tr>
-<input type="hidden" name="memberList[` + index + `].memberCode" value="` + item.memberCode + `" />
-<input type="hidden" name="memberList[` + index + `].password" value="` + item.password + `" />
-`;
-
+        `;
                 $tableBody.append(rowHtml);
             });
 
@@ -687,8 +690,8 @@
                 const phoneNumber = $tr.find('input[name$=".phoneNumber"]').val().trim();
                 const authorityCode = $tr.find('select[name$=".authorityCode"]').val();
                 const id = $tr.find('input[name$=".id"]').val().trim();
-                const memberCode = $tr.find('input[name$=".memberCode"]').val();   // 🔥 수정: next() 대신 find()로
-                const password = $tr.find('input[name$=".password"]').val();       // 🔥 수정: next() 대신 find()로
+                const memberCode = $tr.find('input[name$=".memberCode"]').val();
+                const password = $tr.find('input[name$=".password"]').val();
                 const address = $tr.find('input[name$=".address"]').val().trim();
 
                 if (!regName.test(name)) {
@@ -717,7 +720,6 @@
                     return;
                 }
 
-                // ✅ 검증 통과한 데이터만 리스트에 추가
                 memberList.push({
                     authorityCode,
                     name,
@@ -730,16 +732,15 @@
                 });
             }
 
-            // 최종 확인
             if (!confirm('입력하신 정보로 수정하시겠습니까?')) return;
 
             try {
                 const res = await fetch(contextPath + '/qh/member/update', {
                     method: 'POST',
                     headers: {
-                        'Content-Type': 'application/json'  // JSON 보내겠다고 명시
+                        'Content-Type': 'application/json'
                     },
-                    body: JSON.stringify({ memberList: memberList })  // JSON 배열로 보내기
+                    body: JSON.stringify({ memberList: memberList })
                 });
 
                 if (res.ok) {

--- a/src/main/webapp/WEB-INF/views/qh/member/list.jsp
+++ b/src/main/webapp/WEB-INF/views/qh/member/list.jsp
@@ -744,32 +744,31 @@
             $list.append(li);
         });
 
-        // 모달 열기
-        $('#memberDeleteModal').modal('show');
-    });
-
-    // 삭제 확인 버튼 클릭 시: form에 hidden input 추가하고 전송
-    $('#confirmDelete').on('click', function (e) {
-        const $form = $('#memberDeleteForm');
+            $('#confirmDelete').off('click').on('click', function (e) {
+                const $form = $('#memberDeleteForm');
 
         // 혹시 이전에 추가된 hidden input이 있으면 제거
         $form.find('input[name="memberCodeList"]').remove();
 
-        // <ul> 안의 badge에서 memberCode 꺼내서 hidden input 추가
-        $('#deleteMemberList .badge').each(function () {
-            const memberCode = $(this).text().trim();
-            const input = `<input type="hidden" name="memberCodeList" value="` + memberCode + `" />`;
-            $form.append(input);
+                // 🔥 새로운 hidden input 추가
+                selectedData.forEach((item) => {
+                    $form.append(`
+                <input type="hidden" name="memberCodeList" value="`+item.memberCode+`">
+            `);
+                });
 
-            const result = confirm('선택하신 회원을 삭제 하시겠습니까? ');
-            if (result) {
-                console.log('삭제');
-                $form.submit();
-            } else {
-                console.log('삭제 취소');
-            }
-        });// form 전송
-    });
+                const result = confirm('선택하신 회원을 삭제 하시겠습니까?');
+                if (result) {
+                    console.log('삭제');
+                    $form.submit();
+                } else {
+                    console.log('삭제 취소');
+                }
+            });
+
+            // 모달 열기
+            $('#memberDeleteModal').modal('show');
+        });
 
     //mypageData
     <%@ include file="/WEB-INF/views/includes/mypage/mypageData.jsp" %>

--- a/src/main/webapp/WEB-INF/views/qh/member/list.jsp
+++ b/src/main/webapp/WEB-INF/views/qh/member/list.jsp
@@ -289,7 +289,7 @@
                                     <td><input type="text" name="memberList[${status.index}].email" class="form-control" value="${item.email}" /></td>
                                     <td><input type="text" name="memberList[${status.index}].phoneNumber" class="form-control" value="${item.phoneNumber}" /></td>
                                     <td><input type="text" name="memberList[${status.index}].address" class="form-control" value="${item.address}" /></td>
-                                    <td><input type="text" name="memberList[${status.index}].id" class="form-control" value="${item.id} " readonly/></td>
+                                    <td><input type="text" name="memberList[${status.index}].id" class="form-control" value="${item.id} " /></td>
                                 </tr>
                                 <input type="hidden" name="memberList[${status.index}].memberCode" value="${item.memberCode}" />
                             </c:forEach>
@@ -657,8 +657,8 @@
     <td><input type="text" name="memberList[` + index + `].email" class="form-control" value="` + item.email + `" data-original-email="` + item.email + `" /></td>
     <td><input type="text" name="memberList[` + index + `].phoneNumber" class="form-control" value="` + item.phoneNumber + `" /></td>
     <td><input type="text" name="memberList[` + index + `].address" class="form-control" value="` + item.address + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].id" class="form-control" value="` + item.id + `" /></td>
     <td>
-        <input type="text" name="memberList[` + index + `].id" class="form-control" value="` + item.id + `" readonly />
         <input type="hidden" name="memberList[` + index + `].memberCode" value="` + item.memberCode + `" />
         <input type="hidden" name="memberList[` + index + `].password" value="` + item.password + `" />
     </td>

--- a/src/main/webapp/WEB-INF/views/qh/member/list.jsp
+++ b/src/main/webapp/WEB-INF/views/qh/member/list.jsp
@@ -93,7 +93,7 @@
                                 </thead>
                                 <tbody>
                                 <c:forEach var="member" items="${qhMemberList}">
-                                    <tr>
+                                    <tr data-password="${member.password}">
                                         <td><input type="checkbox" class="row-checkbox" /></td>
                                         <td>${member.memberCode}</td>
                                         <td>${member.name}</td>
@@ -102,7 +102,6 @@
                                         <td>${member.address}</td>
                                         <td>${member.id}</td>
                                     </tr>
-
                                 </c:forEach>
                                 </tbody>
                             </table>
@@ -624,57 +623,52 @@
 
 
         // 수정 버튼 클릭 시
-    $('#btnMemberEdit_clone').on('click', function (e) {
-        const selectedData = [];
+        $('#btnMemberEdit_clone').on('click', function (e) {
+            const selectedData = [];
 
-        // 체크된 행들의 데이터 수집
-        $('#datatable tbody input.row-checkbox:checked').each(function () {
-            const $tr = $(this).closest('tr');
-            const rowData = {
-                memberCode: $tr.find('td').eq(1).text().trim(),
-                name: $tr.find('td').eq(2).text().trim(),
-                phoneNumber: $tr.find('td').eq(3).text().trim(),
-                email: $tr.find('td').eq(4).text().trim(),
-                address: $tr.find('td').eq(5).text().trim(),
-                id: $tr.find('td').eq(6).text().trim()
-            };
-            selectedData.push(rowData);
+            $('#datatable tbody input.row-checkbox:checked').each(function () {
+                const $tr = $(this).closest('tr');
+                const rowData = {
+                    memberCode: $tr.find('td').eq(1).text().trim(),
+                    name: $tr.find('td').eq(2).text().trim(),
+                    phoneNumber: $tr.find('td').eq(3).text().trim(),
+                    email: $tr.find('td').eq(4).text().trim(),
+                    address: $tr.find('td').eq(5).text().trim(),
+                    id: $tr.find('td').eq(6).text().trim(),
+                    password: $tr.data('password') // 🔥 여기!
+                };
+                selectedData.push(rowData);
+            });
+
+            const $tableBody = $('#memberEditModal tbody');
+            $tableBody.empty();
+
+            selectedData.forEach((item, index) => {
+                const rowHtml = `
+<tr>
+    <td><select class="form-select" name="memberList[` + index + `].authorityCode">
+        <option value="QH">본사관리자</option>
+        <option value="WM">창고관리자</option>
+        <option value="FM">가맹점주</option>
+    </select></td>
+    <td><input type="text" name="memberList[` + index + `].name" class="form-control" value="` + item.name + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].email" class="form-control" value="` + item.email + `" data-original-email="` + item.email + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].phoneNumber" class="form-control" value="` + item.phoneNumber + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].address" class="form-control" value="` + item.address + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].id" class="form-control" value="` + item.id + `" readonly /></td>
+</tr>
+<input type="hidden" name="memberList[` + index + `].memberCode" value="` + item.memberCode + `" />
+<input type="hidden" name="memberList[` + index + `].password" value="` + item.password + `" />
+`;
+
+                $tableBody.append(rowHtml);
+            });
+
+            $('#memberEditModal').modal('show');
         });
-
-
-        if (selectedData.length == 0) {
-            alert('수정할 항목을 선택하세요.');
-            return;
-        }
-
-        const $tableBody = $('#memberEditModal tbody');
-        $tableBody.empty();
-
-        selectedData.forEach((item, index) => {
-            const rowHtml = `
-    <tr>
-         <td><select class="form-select"  name="memberList[` + index + `].authorityCode">
-              <option value="QH">본사관리자</option>
-              <option value="WM">창고관리자</option>
-              <option value="FM">가맹점주</option>
-            </select></td>
-        <td><input type="text" name="memberList[` + index + `].name" class="form-control" value="` + item.name + `" /></td>
-        <td><input type="text" name="memberList[` + index + `].email" class="form-control" value="` + item.email + `" /></td>
-        <td><input type="text" name="memberList[` + index + `].phoneNumber" class="form-control" value="` + item.phoneNumber + `" /></td>
-        <td><input type="text" name="memberList[` + index + `].address" class="form-control" value="` + item.address + `" /></td>
-        <td><input type="text" name="memberList[` + index + `].id" class="form-control" value="` + item.id + `" /></td>
-        </tr>
-        <input type="hidden" name="memberList[` + index + `].memberCode" value="` + item.memberCode + `" />
-
-    `;
-            $tableBody.append(rowHtml);
-        });
-
-        $('#memberEditModal').modal('show');
-    });
 
         //수정 클릭 시 confirm
-        $('#modify-bnt').on('click', async function(e) {
+        $('#modify-bnt').on('click', async function (e) {
             e.preventDefault();
 
             const regName  = /^[A-Za-z가-힣]{1,10}$/;
@@ -682,12 +676,13 @@
             const regPhone = /^[0-9]{10,11}$/;
             const contextPath = '${pageContext.request.contextPath}';
 
-            // 1) 각 행 순회하면서 유효성·중복 검사
             const $rows = $('#memberEditModal tbody tr');
             for (let i = 0; i < $rows.length; i++) {
                 const $tr = $($rows[i]);
-                const name        = $tr.find('input[name$=".name"]').val().trim();
-                const email       = $tr.find('input[name$=".email"]').val().trim();
+                const name = $tr.find('input[name$=".name"]').val().trim();
+                const emailInput = $tr.find('input[name$=".email"]');
+                const email = emailInput.val().trim();
+                const originalEmail = emailInput.attr('data-original-email');
                 const phoneNumber = $tr.find('input[name$=".phoneNumber"]').val().trim();
 
                 if (!regName.test(name)) {
@@ -698,17 +693,18 @@
                     alert(name + ' 님의 이메일 형식이 올바르지 않습니다.');
                     return;
                 }
-                // 이메일 중복 체크
-                try {
-                    const res = await fetch(`${contextPath}/qh/member/emailCheck?email=` + encodeURIComponent(email));
-                    const text = await res.text();
-                    if (text === 'true') {
-                        alert(name + ' 님의 이메일은 이미 사용 중입니다.');
+                if (email !== originalEmail) { // 이메일이 수정된 경우만 체크
+                    try {
+                        const res = await fetch(contextPath + '/qh/member/emailCheck?email=' + encodeURIComponent(email));
+                        const text = await res.text();
+                        if (text === 'true') {
+                            alert(name + ' 님의 이메일은 이미 사용 중입니다.');
+                            return;
+                        }
+                    } catch (err) {
+                        alert('이메일 중복 확인 중 오류가 발생했습니다.');
                         return;
                     }
-                } catch (err) {
-                    alert('이메일 중복 확인 중 오류가 발생했습니다.');
-                    return;
                 }
                 if (phoneNumber && !regPhone.test(phoneNumber)) {
                     alert(name + ' 님의 전화번호 형식이 올바르지 않습니다. (10~11자리 숫자)');
@@ -722,11 +718,10 @@
             // 3) FormData → URLSearchParams 변환
             const formElem = document.getElementById('memberEditForm');
             const formData = new FormData(formElem);
-            const body     = new URLSearchParams(formData);
+            const body = new URLSearchParams(formData);
 
-            // 4) fetch 비동기 전송
             try {
-                const res = await fetch(contextPath + `/qh/member/update`, {
+                const res = await fetch(contextPath + '/qh/member/update', {
                     method: 'POST',
                     body
                 });
@@ -743,8 +738,6 @@
                 alert('서버와 연결에 실패했습니다.');
             }
         });
-
-
         //valid시 에러시 모달 원복
     window.addEventListener('DOMContentLoaded', function () {
         <c:if test="${not empty errorMessage}">

--- a/src/main/webapp/WEB-INF/views/qh/member/list.jsp
+++ b/src/main/webapp/WEB-INF/views/qh/member/list.jsp
@@ -623,6 +623,50 @@
 
 
         // 수정 버튼 클릭 시
+        $('#btnMemberEdit_clone').on('click', function (e) {
+            const selectedData = [];
+
+            $('#datatable tbody input.row-checkbox:checked').each(function () {
+                const $tr = $(this).closest('tr');
+                const rowData = {
+                    memberCode: $tr.find('td').eq(1).text().trim(),
+                    name: $tr.find('td').eq(2).text().trim(),
+                    phoneNumber: $tr.find('td').eq(3).text().trim(),
+                    email: $tr.find('td').eq(4).text().trim(),
+                    address: $tr.find('td').eq(5).text().trim(),
+                    id: $tr.find('td').eq(6).text().trim(),
+                    password: $tr.data('password') // 🔥 여기!
+                };
+                selectedData.push(rowData);
+            });
+
+            const $tableBody = $('#memberEditModalBody');
+            $tableBody.empty();
+
+            selectedData.forEach((item, index) => {
+                const rowHtml = `
+<tr>
+    <td><select class="form-select" name="memberList[` + index + `].authorityCode">
+        <option value="QH">본사관리자</option>
+        <option value="WM">창고관리자</option>
+        <option value="FM">가맹점주</option>
+    </select></td>
+    <td><input type="text" name="memberList[` + index + `].name" class="form-control" value="` + item.name + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].email" class="form-control" value="` + item.email + `" data-original-email="` + item.email + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].phoneNumber" class="form-control" value="` + item.phoneNumber + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].address" class="form-control" value="` + item.address + `" /></td>
+    <td><input type="text" name="memberList[` + index + `].id" class="form-control" value="` + item.id + `" readonly /></td>
+</tr>
+<input type="hidden" name="memberList[` + index + `].memberCode" value="` + item.memberCode + `" />
+<input type="hidden" name="memberList[` + index + `].password" value="` + item.password + `" />
+`;
+
+                $tableBody.append(rowHtml);
+            });
+
+            $('#memberEditModal').modal('show');
+        });
+        //수정 클릭 시 confirm
         $('#modify-bnt').on('click', async function (e) {
             e.preventDefault();
 
@@ -631,7 +675,7 @@
             const regPhone = /^[0-9]{10,11}$/;
             const contextPath = '${pageContext.request.contextPath}';
 
-            const $rows = $('#memberEditModal tbody tr');
+            const $rows = $('#memberEditModalBody tr');
             const memberList = [];
 
             for (let i = 0; i < $rows.length; i++) {
@@ -643,8 +687,9 @@
                 const phoneNumber = $tr.find('input[name$=".phoneNumber"]').val().trim();
                 const authorityCode = $tr.find('select[name$=".authorityCode"]').val();
                 const id = $tr.find('input[name$=".id"]').val().trim();
-                const memberCode = $tr.next('input[type="hidden"]').val();
-                const password = $tr.next('input[type="hidden"][name$=".password"]').val();
+                const memberCode = $tr.find('input[name$=".memberCode"]').val();   // 🔥 수정: next() 대신 find()로
+                const password = $tr.find('input[name$=".password"]').val();       // 🔥 수정: next() 대신 find()로
+                const address = $tr.find('input[name$=".address"]').val().trim();
 
                 if (!regName.test(name)) {
                     alert(name + ' 님의 이름이 올바르지 않습니다. (한글/영어 최대 10자)');
@@ -672,13 +717,13 @@
                     return;
                 }
 
-                // 검증 통과한 데이터만 리스트에 추가
+                // ✅ 검증 통과한 데이터만 리스트에 추가
                 memberList.push({
                     authorityCode,
                     name,
                     email,
                     phoneNumber,
-                    address: $tr.find('input[name$=".address"]').val().trim(),
+                    address,
                     id,
                     memberCode,
                     password


### PR DESCRIPTION
## #️⃣ Issue Number
#75

## 📝 요약 (Summary)
회원가입, 로그인, 아이디/비밀번호 찾기, 마이페이지, 회원관리 기능 수정 및 버그 수정

## 🛠️ 작업 내용

- [x] 시큐리티: 로그인 사용자의 home 화면 접근 제한
- [x] 회원가입: confirm 창 호출 이후 취소해도 수정불가했던 버그 수정
- [x] 아이디/비밀번호 찾기
  - 조회 성공 시 클립보드 자동 복사 기능 추가
  - 로그인 화면 이동 여부 확인 알림창(confirm) 추가
- [x] 마이페이지
  - 회원 탈퇴 기능 수정 및 확인
  - 아이디 수정 제한 (이미 적용되어 있었음 확인)
  - 회원 수정 기능 정상 확인
  - 비밀번호 표시/숨김 아이콘 클릭 시 비밀번호 text 조회 및 수정 기능추가
- [x] 회원관리
  - 삭제 시 삭제창이 중복 생성되던 버그 수정
  - 회원 수정 기능 비동기 방식(fetch + JSON List 전송)으로 변경
  - 회원 수정 시 클라이언트 유효성 검사 추가
  - 이메일 수정 시 기존 이메일과 동일하면 중복 검사 생략
  - 회원 목록 및 수정 화면에서 비밀번호 항목 제거
  - 마이페이지에서 본인 비밀번호 수정 가능하도록 변경
  - 아이디 수정할 수 있도록 변경
  - 회원 권한 수정 시 회원코드 변경되도록 수정
 
## ✅ PR 체크리스트

- [x] 커밋 메시지를 컨벤션에 맞게 작성했나요?
- [x] 로컬에서 테스트를 완료했나요?
- [x] 코드 스타일 가이드를 따랐나요?
