### PR TITLE
Feat/vehicle

### DIFF
--- a/src/main/java/com/donut/prokindonutsweb/order/controller/OrderController.java
+++ b/src/main/java/com/donut/prokindonutsweb/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.donut.prokindonutsweb.order.controller;
 
 
+import com.donut.prokindonutsweb.common.EmailUtil;
 import com.donut.prokindonutsweb.inbound.dto.ProductDTO;
 import com.donut.prokindonutsweb.inbound.service.InboundService;
 import com.donut.prokindonutsweb.inbound.exception.ErrorType;
@@ -11,10 +12,12 @@ import com.donut.prokindonutsweb.order.dto.OrderForm;
 import com.donut.prokindonutsweb.order.dto.OrderStatus;
 import com.donut.prokindonutsweb.order.service.OrderService;
 import com.donut.prokindonutsweb.outbound.dto.OutboundDTO;
+import com.donut.prokindonutsweb.outbound.service.OutboundService;
 import com.donut.prokindonutsweb.security.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,9 +40,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 @RequestMapping("/fm")
 public class OrderController {
 
-    @Autowired
+    private final EmailUtil emailUtil;
+    private final JavaMailSender javaMailSender;
     private final InboundService inboundService;
-    @Autowired private final OrderService orderService;
+    private final OrderService orderService;
 
     // 발주 요청에 필요한 제품 목록 출력
     @GetMapping("/order")
@@ -110,6 +114,10 @@ public class OrderController {
 
             //출고 저장 생성
             orderService.addOutbound(warehouseCode,dto,orderDetailList);
+
+            //메일발송
+            emailUtil.sendDeliveryStatusEmail(javaMailSender,memberCode,"배송준비" );
+
 
             redirectAttributes.addFlashAttribute("successMessage", "발주 요청이 완료되었습니다!");
         } catch (Exception e) {

--- a/src/main/java/com/donut/prokindonutsweb/outbound/controller/OutboundApprovalController.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/controller/OutboundApprovalController.java
@@ -1,5 +1,6 @@
 package com.donut.prokindonutsweb.outbound.controller;
 
+import com.donut.prokindonutsweb.common.mapper.UserInfoMapper;
 import com.donut.prokindonutsweb.outbound.dto.OutboundDTO;
 import com.donut.prokindonutsweb.outbound.service.OutboundService;
 import com.donut.prokindonutsweb.security.dto.CustomUserDetails;
@@ -23,6 +24,7 @@ import java.util.List;
 public class OutboundApprovalController {
 
     private final OutboundService outboundService;
+    private final UserInfoMapper userInfoMapper;
 
     @GetMapping("/approval")
     public String getOutboundList(Model model, @AuthenticationPrincipal CustomUserDetails user) {
@@ -40,7 +42,9 @@ public class OutboundApprovalController {
     }
 
     @PostMapping("/approval")
-    public String approveOutbound(@RequestParam("outboundCodeList") List<String> outboundCodeList, RedirectAttributes redirectAttributes) {
+    public String approveOutbound(@AuthenticationPrincipal CustomUserDetails user,@RequestParam("outboundCodeList") List<String> outboundCodeList, RedirectAttributes redirectAttributes) {
+        String warehouseCode = userInfoMapper.getWarehouseCode(user.getMemberCode());
+
         for (String outboundCode : outboundCodeList) {
             log.info("출고코드: {}", outboundCode);
 
@@ -53,7 +57,7 @@ public class OutboundApprovalController {
                 // 상태 변경 ( -> 출고 준비)
                 outboundService.approveOutbound(outboundCode);
                 // 재고 반영
-                outboundService.updateInventory(outboundCode);
+                outboundService.updateInventory(outboundCode,warehouseCode);
                 redirectAttributes.addFlashAttribute("errorMessage", "출고가 완료되었습니다.");
             } else {
                 // 출고 X 에러 메시지 반환

--- a/src/main/java/com/donut/prokindonutsweb/outbound/controller/OutboundApprovalController.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/controller/OutboundApprovalController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -28,7 +30,6 @@ public class OutboundApprovalController {
 
     @GetMapping("/approval")
     public String getOutboundList(Model model, @AuthenticationPrincipal CustomUserDetails user) {
-        log.info("check");
 
         String memberCode = user.getMemberCode();
         log.info(memberCode);
@@ -45,27 +46,37 @@ public class OutboundApprovalController {
     public String approveOutbound(@AuthenticationPrincipal CustomUserDetails user,@RequestParam("outboundCodeList") List<String> outboundCodeList, RedirectAttributes redirectAttributes) {
         String warehouseCode = userInfoMapper.getWarehouseCode(user.getMemberCode());
 
+        List<String> successList = new ArrayList<>();
+        List<String> failList = new ArrayList<>();
+        List<String> noVehicleList = new ArrayList<>();
+
         for (String outboundCode : outboundCodeList) {
             log.info("출고코드: {}", outboundCode);
 
             // 재고 존재 확인
-            boolean check = outboundService.checkInventory(outboundCode);
-            log.info(String.valueOf(check));
-
-            // 존재하면 출고 처리
-            if (check) {
-                // 상태 변경 ( -> 출고 준비)
-                outboundService.approveOutbound(outboundCode);
-                // 재고 반영
-                outboundService.updateInventory(outboundCode,warehouseCode);
-                redirectAttributes.addFlashAttribute("errorMessage", "출고가 완료되었습니다.");
+            if (outboundService.checkInventory(outboundCode)) {
+                try {
+                    //존재하면 출고 처리(상태 변경 : 출고 준비)
+                    outboundService.approveOutbound(outboundCode);
+                    // 재고 반영
+                    outboundService.updateInventory(outboundCode,warehouseCode);
+                    //차량배치
+                    boolean vehicleAssigned = outboundService.outboundVehicle(outboundCode);
+                    if (vehicleAssigned) successList.add(outboundCode);
+                     else noVehicleList.add(outboundCode);
+                } catch (Exception e) {
+                    log.info("출고 처리 중 오류 발생: {}", e.getMessage());
+                    failList.add(outboundCode);
+                }
             } else {
-                // 출고 X 에러 메시지 반환
-                redirectAttributes.addFlashAttribute("errorMessage", "재고가 부족해 출고할 수 없습니다.");
+                failList.add(outboundCode);
             }
         }
-
+        if (!successList.isEmpty()) redirectAttributes.addFlashAttribute("successMessage", successList.size() + "건 출고 완료했습니다.");
+        if (!noVehicleList.isEmpty()) redirectAttributes.addFlashAttribute("vehicleFailMessage", noVehicleList.size() + "건은 배차 불가");
+        if (!failList.isEmpty()) redirectAttributes.addFlashAttribute("errorMessage", failList.size() + "건 출고 실패 (재고 부족 등)");
 
         return "redirect:/wm/outbound/approval";
     }
+
 }

--- a/src/main/java/com/donut/prokindonutsweb/outbound/dto/VehicleDTO.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/dto/VehicleDTO.java
@@ -1,0 +1,16 @@
+package com.donut.prokindonutsweb.outbound.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class VehicleDTO {
+    private String outboundCode;
+    private String warehouseCode;
+    private String storedType;
+    private int quantity;
+    private LocalDate outboundDate;
+}

--- a/src/main/java/com/donut/prokindonutsweb/outbound/dto/VehicleScheduleDTO.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/dto/VehicleScheduleDTO.java
@@ -1,0 +1,15 @@
+package com.donut.prokindonutsweb.outbound.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class VehicleScheduleDTO {
+    private String vehicleCode;
+    private LocalDate dispatchDate;
+    private int quantity;
+
+}

--- a/src/main/java/com/donut/prokindonutsweb/outbound/mapper/OutboundMapper.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/mapper/OutboundMapper.java
@@ -21,11 +21,14 @@ public interface OutboundMapper {
     void completionOrder(String outboundCode);
 
     void updateInventory(String outboundCode);
+    void updateInventoryCode(OutboundVO outboundVO);
 
     String getWarehouseCode(String memberCode);
 
     void updateSection(@Param("sectionCode") String sectionCode, @Param("quantity") int quantity);
     void insertOutbound(OutboundVO outboundVO);
     String selectOutboundCode();
+    OutboundVO selectOutboundVoOne(String outboundCode);
+    OutboundDTO selectOutboundDtoOne(String outboundCode);
 
 }

--- a/src/main/java/com/donut/prokindonutsweb/outbound/mapper/OutboundMapper.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/mapper/OutboundMapper.java
@@ -1,9 +1,14 @@
 package com.donut.prokindonutsweb.outbound.mapper;
 
 import com.donut.prokindonutsweb.outbound.dto.OutboundDTO;
+import com.donut.prokindonutsweb.outbound.dto.VehicleDTO;
+import com.donut.prokindonutsweb.outbound.dto.VehicleScheduleDTO;
 import com.donut.prokindonutsweb.outbound.vo.OutboundVO;
+import com.donut.prokindonutsweb.outbound.vo.VehicleScheduleVO;
+import com.donut.prokindonutsweb.outbound.vo.VehicleVO;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface OutboundMapper {
@@ -30,5 +35,12 @@ public interface OutboundMapper {
     String selectOutboundCode();
     OutboundVO selectOutboundVoOne(String outboundCode);
     OutboundDTO selectOutboundDtoOne(String outboundCode);
-
+    VehicleScheduleDTO selectVehicle(VehicleDTO vehicleDTO);
+    int countRegisteredVehicleSchedule(VehicleDTO vehicleDTO);
+    int countAllVehiclesInWarehouse(VehicleDTO vehicleDTO);
+    VehicleDTO getVehicleDTO(@Param("outboundCode") String outboundCode);
+    void insertVehicleSchedule(VehicleScheduleVO vehicleScheduleVO);
+    List<VehicleVO> getVehicleVO(String warehouseCode);
+    String selectVehicleScheduleCode();
+    void updateVehicleSchedule(VehicleScheduleDTO vehicleScheduleDTO);
 }

--- a/src/main/java/com/donut/prokindonutsweb/outbound/service/OutboundService.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/service/OutboundService.java
@@ -20,7 +20,7 @@ public interface OutboundService {
     void completionOrder(String outboundCode);
     void SectionUpdate(String sectionCode ,int quantity);
     String getSectionCode(String warehouseCode, String outboundCode);
-    void updateInventory(String outboundCode);
+    void updateInventory(String outboundCode,String warehouseCode);
 
     String getWarehouseCode(String memberCode);
 }

--- a/src/main/java/com/donut/prokindonutsweb/outbound/service/OutboundService.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/service/OutboundService.java
@@ -1,6 +1,9 @@
 package com.donut.prokindonutsweb.outbound.service;
 
 import com.donut.prokindonutsweb.outbound.dto.OutboundDTO;
+import com.donut.prokindonutsweb.outbound.dto.VehicleDTO;
+import com.donut.prokindonutsweb.outbound.dto.VehicleScheduleDTO;
+import com.donut.prokindonutsweb.outbound.vo.OutboundVO;
 
 import java.util.List;
 
@@ -21,6 +24,10 @@ public interface OutboundService {
     void SectionUpdate(String sectionCode ,int quantity);
     String getSectionCode(String warehouseCode, String outboundCode);
     void updateInventory(String outboundCode,String warehouseCode);
-
     String getWarehouseCode(String memberCode);
+    VehicleScheduleDTO getVehicle(VehicleDTO vehicleDTO);
+    boolean outboundVehicle(String outboundCode);
+    void addVehicleshcedule(VehicleScheduleDTO vehicleScheduleDTO);
+    boolean getVehicleSchedule(VehicleDTO vehicleDTO);
+    void insertVehicleSchedule(VehicleDTO vehicleDTO);
 }

--- a/src/main/java/com/donut/prokindonutsweb/outbound/service/OutboundServiceImpl.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/service/OutboundServiceImpl.java
@@ -1,9 +1,13 @@
 package com.donut.prokindonutsweb.outbound.service;
 
+import com.donut.prokindonutsweb.common.EmailUtil;
+import com.donut.prokindonutsweb.order.mapper.OrderMapper;
 import com.donut.prokindonutsweb.outbound.dto.OutboundDTO;
 import com.donut.prokindonutsweb.outbound.mapper.OutboundMapper;
+import com.donut.prokindonutsweb.outbound.vo.OutboundVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +18,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OutboundServiceImpl implements OutboundService{
 
+    private final EmailUtil emailUtil;
+    private final JavaMailSender javaMailSender;
     private final OutboundMapper outboundMapper;
+    private final OrderMapper orderMapper;
+
 
     //출고목록 조회
     @Override
@@ -52,10 +60,12 @@ public class OutboundServiceImpl implements OutboundService{
     public void completionOutbound(String outboundCode) {
         outboundMapper.completionOutbound(outboundCode);
     }
-    // 발주상태 변경 (배송준비 -> 배송중)
+    // 발주상태 변경 (배송준비 -> 배송중) 후 메일발송
     @Override
     public void completionOrder(String outboundCode) {
+        log.info("발주상태 변경");
         outboundMapper.completionOrder(outboundCode);
+        emailUtil.sendDeliveryStatusEmail(javaMailSender,outboundCode,"배송중" );
     }
 
     //보관타입 조회

--- a/src/main/java/com/donut/prokindonutsweb/outbound/service/OutboundServiceImpl.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/service/OutboundServiceImpl.java
@@ -107,8 +107,30 @@ public class OutboundServiceImpl implements OutboundService{
 
     // 재고 반영
     @Override
-    public void updateInventory(String outboundCode) {
-        outboundMapper.updateInventory(outboundCode);
+    public void updateInventory(String outboundCode , String warehouseCode) {
+        //  VO와 DTO 조회
+        OutboundVO outboundVO = outboundMapper.selectOutboundVoOne(outboundCode);
+        OutboundDTO outboundDTO = outboundMapper.selectOutboundDtoOne(outboundCode);
+
+        //  재고 코드 존재 여부에 따라 처리
+        if (outboundVO.getInventoryCode() != null) {
+            // 기존 재고 차감 처리
+            outboundMapper.updateInventory(outboundCode);
+        } else {
+            // 재고 코드가 없으면 재고 코드 검색 후 VO에 세팅
+            String inventoryCode = orderMapper.findInventoryCode(
+                    warehouseCode,
+                    outboundDTO.getProductCode(),
+                    Integer.parseInt(outboundDTO.getQuantity())
+            );
+
+            // 재고 코드 세팅 및 DB에 반영
+            outboundVO.setInventoryCode(inventoryCode);
+            outboundMapper.updateInventoryCode(outboundVO);
+
+            // 이후 차감 처리
+            outboundMapper.updateInventory(outboundCode);
+        }
     }
 
     //창고코드 조회

--- a/src/main/java/com/donut/prokindonutsweb/outbound/vo/VehicleScheduleVO.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/vo/VehicleScheduleVO.java
@@ -1,0 +1,16 @@
+package com.donut.prokindonutsweb.outbound.vo;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class VehicleScheduleVO {
+    private String vehicleScheduleCode;
+    private String vehicleCode;
+    private LocalDate dispatchDate;
+    private int remainingCapacity;
+
+}

--- a/src/main/java/com/donut/prokindonutsweb/outbound/vo/VehicleVO.java
+++ b/src/main/java/com/donut/prokindonutsweb/outbound/vo/VehicleVO.java
@@ -1,0 +1,16 @@
+package com.donut.prokindonutsweb.outbound.vo;
+
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+@Builder
+public class VehicleVO {
+    private String vehicleCode;
+    private String warehouseCode;
+    private String type;
+    private int capacity;
+    private String vehicleNum;
+
+}

--- a/src/main/resources/mappers/outbound/outboundMapper.xml
+++ b/src/main/resources/mappers/outbound/outboundMapper.xml
@@ -145,6 +145,26 @@
         Select outboundCode From outbound order by CAST(substring(outboundCode, 3) AS UNSIGNED) DESC LIMIT 1
     </select>
 
+    <select id="selectOutboundVoOne"  resultType="com.donut.prokindonutsweb.outbound.vo.OutboundVO">
+        SELECT * FROM outbound o WHERE o.outboundCode = #{outboundCode}
+    </select>
+
+    <select id="selectOutboundDtoOne"  resultType="com.donut.prokindonutsweb.outbound.dto.OutboundDTO">
+        SELECT
+        o.outboundCode,
+        p.productCode,
+        p.productName,
+        o.outboundDate,
+        o.vehicleCode,
+        od.franchiseCode,
+        o.outboundStatus
+        FROM outbound o
+        JOIN inventory i ON o.inventoryCode = i.inventoryCode
+        JOIN product p ON i.productCode = p.productCode
+        JOIN orderdetail odd ON o.orderDetailCode = odd.orderDetailCode
+        JOIN `order` od ON od.orderCode = odd.orderCode
+        WHERE o.outboundCode = #{outboundCode}
+    </select>
 
 
 </mapper>

--- a/src/main/resources/mappers/outbound/outboundMapper.xml
+++ b/src/main/resources/mappers/outbound/outboundMapper.xml
@@ -166,5 +166,12 @@
         WHERE o.outboundCode = #{outboundCode}
     </select>
 
+    <!--출고 승인 시 재고 코드 등록-->
+    <update id="updateInventoryCode">
+        update outbound set inventoryCode = #{inventoryCode}
+        where outboundCode = #{outboundCode}
+    </update>
+
+
 
 </mapper>

--- a/src/main/resources/mappers/outbound/outboundMapper.xml
+++ b/src/main/resources/mappers/outbound/outboundMapper.xml
@@ -172,6 +172,88 @@
         where outboundCode = #{outboundCode}
     </update>
 
+    <!--최적 차량 조회
+    1. 해당 창고 보유 차량 중
+    2. 출고요청일 2일 이내에(우선순위 : 당일 > 하루전 > 이틀전)
+    3. 제품과 보관타입 일치
+    4. 잔여 적재용량 존재
+    5. 제품 출고량 적재가능한 차량 중
+    6. 가장 잔여 적재용량이 큰 차량 조회
+    -->
+    <select id="selectVehicle" resultType="com.donut.prokindonutsweb.outbound.dto.VehicleScheduleDTO">
+        select v.vehicleCode , vs.dispatchDate , o.quantity
+        from outbound o
+        left join inventory i on o.inventoryCode = i.inventoryCode
+        left join warehouse w on i.warehouseCode = w.warehouseCode
+        right join vehicle v on  v.warehouseCode = w. warehouseCode
+        left join vehicleschedule vs on v.vehicleCode = vs.vehicleCode
+        where o.outboundCode = #{outboundCode}
+        and vs.dispatchDate IN ( #{outboundDate} ,
+                                 DATE_SUB(#{outboundDate}, INTERVAL 1 DAY),
+                                 DATE_SUB(#{outboundDate}, INTERVAL 2 DAY))
+        and v.type = #{storedType}
+        and vs.remainingCapacity > 0
+        and vs.remainingCapacity - #{quantity} >= 0
+        order by case vs.dispatchDate
+            when #{outboundDate} THEN 0
+            when DATE_SUB(#{outboundDate}, INTERVAL 1 DAY) THEN 1
+            when DATE_SUB(#{outboundDate}, INTERVAL 2 DAY) THEN 2
+            else 3
+            end, v.capacity desc limit 1
+    </select>
 
+    <!--출고요청일 포함 3일 내의 해당창고의 차량이 차량스케쥴표에 등록되어있는 차량수 조회-->
+    <select id="countRegisteredVehicleSchedule" resultType="int">
+        select count(distinct v.vehicleCode)
+        from vehicleschedule vs
+        join vehicle v on  v.vehicleCode = vs. vehicleCode
+        and vs.dispatchDate IN (#{outboundDate},
+                                DATE_SUB(#{outboundDate}, INTERVAL 1 DAY),
+                                DATE_SUB(#{outboundDate}, INTERVAL 2 DAY)
+        )
+        and v.type = #{storedType}
+        and v.warehouseCode = #{warehouseCode}
+    </select>
+
+    <!-- 해당 창고의 보관타입이 출고제품의 보관타입과 일치하는 차량의 수 조회 -->
+    <select id="countAllVehiclesInWarehouse" resultType="int">
+        select count(distinct vehicleCode)
+        from vehicle
+        where warehouseCode = #{warehouseCode}
+        and type = #{storedType}
+    </select>
+
+    <!--차량DTO조회 -->
+    <select id="getVehicleDTO" resultType="com.donut.prokindonutsweb.outbound.dto.VehicleDTO">
+        select o.outboundCode , i.warehouseCode , p.storedType , o.quantity, o.outboundDate
+        from outbound o
+        join inventory i on o.inventoryCode = i.inventoryCode
+        join product p on i.productCode = p.productCode
+        where o.outboundCode = #{outboundCode}
+    </select>
+
+    <!--차량VO조회 -->
+    <select id="getVehicleVO" resultType="com.donut.prokindonutsweb.outbound.vo.VehicleVO">
+        select vehicleCode , warehouseCode , type , capacity, vehicleNum
+        from vehicle
+        where warehouseCode = #{warehouseCode}
+    </select>
+
+    <!--해당날짜의 창고의 모든 차량을 스케쥴표에 등록 (중복제외)-->
+    <insert id="insertVehicleSchedule">
+        insert ignore into vehicleschedule (VehicleScheduleCode , dispatchDate , remainingCapacity, vehicleCode)
+        values (#{vehicleScheduleCode},#{dispatchDate},#{remainingCapacity},#{vehicleCode})
+    </insert>
+
+    <!--    최신 차량스케줄코드 조회 -->
+    <select id="selectVehicleScheduleCode" resultType="String">
+        Select vehicleScheduleCode From vehicleschedule order by CAST(substring(vehicleScheduleCode, 3) AS UNSIGNED) DESC LIMIT 1
+    </select>
+
+    <!--   차량스케줄코드 (잔여 적재량 차감) -->
+    <update id="updateVehicleSchedule">
+        update vehicleschedule set remainingCapacity = remainingCapacity - #{quantity}
+        where vehicleCode = #{vehicleCode} and dispatchDate = #{dispatchDate}
+    </update>
 
 </mapper>

--- a/src/main/webapp/WEB-INF/views/wm/outbound/approval.jsp
+++ b/src/main/webapp/WEB-INF/views/wm/outbound/approval.jsp
@@ -439,5 +439,16 @@
         alert('${errorMessage}');
     </script>
 </c:if>
+
+<c:if test="${not empty successMessage}">
+    <div class="alert alert-success">${successMessage}</div>
+</c:if>
+<c:if test="${not empty inventoryErrorMessage}">
+    <div class="alert alert-danger">${inventoryErrorMessage}</div>
+</c:if>
+<c:if test="${not empty vehicleErrorMessage}">
+    <div class="alert alert-warning">${vehicleErrorMessage}</div>
+</c:if>
+
 </body>
 </html>

--- a/src/test/java/com/donut/prokindonutsweb/outbound/mapper/OutboundMapperTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/outbound/mapper/OutboundMapperTest.java
@@ -1,7 +1,11 @@
 package com.donut.prokindonutsweb.outbound.mapper;
 
 import com.donut.prokindonutsweb.outbound.dto.OutboundDTO;
+import com.donut.prokindonutsweb.outbound.dto.VehicleDTO;
+import com.donut.prokindonutsweb.outbound.dto.VehicleScheduleDTO;
 import com.donut.prokindonutsweb.outbound.vo.OutboundVO;
+import com.donut.prokindonutsweb.outbound.vo.VehicleScheduleVO;
+import com.donut.prokindonutsweb.outbound.vo.VehicleVO;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -118,4 +122,75 @@ public class OutboundMapperTest {
         log.info("outboundDTO : {}", outboundDTO);
     }
 
+    @Test
+    @DisplayName("배치 차량 조회")
+    void selectVehicleCode(){
+        VehicleDTO vehicleDTO = VehicleDTO.builder()
+                .storedType("냉장")
+                .warehouseCode("GG1")
+                .outboundDate(LocalDate.parse("2025-01-13"))
+                .outboundCode("OB005")
+                .quantity(45)
+                .build();
+        VehicleScheduleDTO vehicleScheduleDTO = outboundMapper.selectVehicle(vehicleDTO);
+        log.info("vehicleScheduleDTO : {}",vehicleScheduleDTO);
+    }
+
+    @Test
+    @DisplayName("출고일포함 3일내 스케쥴에 등록되어있는 차량 수 ")
+    void countRegisteredVehicleSchedule(){
+        VehicleDTO vehicleDTO = VehicleDTO.builder()
+                .storedType("냉장")
+                .warehouseCode("GG1")
+                .outboundDate(LocalDate.parse("2025-01-13"))
+                .outboundCode("OB005")
+                .quantity(45)
+                .build();
+        int countRegisteredVehicleSchedule = outboundMapper.countRegisteredVehicleSchedule(vehicleDTO);
+        log.info(String.valueOf(countRegisteredVehicleSchedule));
+    }
+    @Test
+    @DisplayName("해당 창고의 보관타입이 일치하는 차량 수 조회  ")
+    void countAllVehiclesInWarehouse(){
+        VehicleDTO vehicleDTO = VehicleDTO.builder()
+                .storedType("냉장")
+                .warehouseCode("GG1")
+                .outboundDate(LocalDate.parse("2025-01-13"))
+                .outboundCode("OB005")
+                .quantity(45)
+                .build();
+        int countAllVehiclesInWarehouse = outboundMapper.countAllVehiclesInWarehouse(vehicleDTO);
+        log.info(String.valueOf(countAllVehiclesInWarehouse));
+    }
+
+    @Test
+    @DisplayName("차량DTO조회")
+    void getVehicleDTO(){
+        VehicleDTO vehicleDTO = outboundMapper.getVehicleDTO("OB005");
+        log.info("vehicleDTO : {}",vehicleDTO);
+    }
+    @Test
+    @DisplayName("차량VO조회")
+    void getVehicleVO(){
+        List<VehicleVO> vehicleVOs = outboundMapper.getVehicleVO("GG1");
+        vehicleVOs.forEach(vehicleVO -> log.info("vehicleVO : {}",vehicleVO));
+    }
+
+    @Test
+    @DisplayName("최신차량 스케줄 코드 조회")
+    void selectVehicleScheduleCode(){
+        String code = outboundMapper.selectVehicleScheduleCode();
+        log.info(code);
+    }
+
+    @Test
+    @DisplayName("차량스케줄코드 등록(잔여 적재량 차감)")
+    void updateVehicleSchedule(){
+        VehicleScheduleDTO vehicleScheduleDTO = VehicleScheduleDTO.builder()
+                .vehicleCode("V010")
+                .dispatchDate(LocalDate.parse("2025-01-13"))
+                .quantity(45)
+                .build();
+        outboundMapper.updateVehicleSchedule(vehicleScheduleDTO);
+    }
 }

--- a/src/test/java/com/donut/prokindonutsweb/outbound/mapper/OutboundMapperTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/outbound/mapper/OutboundMapperTest.java
@@ -107,4 +107,15 @@ public class OutboundMapperTest {
         log.info(outboundCode);
     }
 
+
+    @Test
+    @DisplayName("출고 반환 메서드 테스트")
+    void selectOutboundOne() {
+        OutboundVO outboundVO = outboundMapper.selectOutboundVoOne("OB001");
+        OutboundDTO outboundDTO = outboundMapper.selectOutboundDtoOne("OB001");
+
+        log.info("outboundVO : {}", outboundVO);
+        log.info("outboundDTO : {}", outboundDTO);
+    }
+
 }

--- a/src/test/java/com/donut/prokindonutsweb/outbound/service/OutboundServiceImplTest.java
+++ b/src/test/java/com/donut/prokindonutsweb/outbound/service/OutboundServiceImplTest.java
@@ -1,6 +1,8 @@
 package com.donut.prokindonutsweb.outbound.service;
 
 import com.donut.prokindonutsweb.outbound.dto.OutboundDTO;
+import com.donut.prokindonutsweb.outbound.dto.VehicleDTO;
+import com.donut.prokindonutsweb.outbound.dto.VehicleScheduleDTO;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -57,5 +60,38 @@ public class OutboundServiceImplTest {
         log.info(sectionCode);
     }
 
+    @Test
+    @DisplayName("출고요청일 2일 이전까지 창고의 모든 차량이 차량스케쥴표에 등록되어있는 지 조회")
+    void getVehicleSchedule(){
+        VehicleDTO vehicleDTO = VehicleDTO.builder()
+                .storedType("냉장")
+                .warehouseCode("GG1")
+                .outboundDate(LocalDate.parse("2025-01-13"))
+                .outboundCode("OB005")
+                .quantity(45)
+                .build();
+        boolean scheduledCount = outboundService.getVehicleSchedule(vehicleDTO);
+        log.info(scheduledCount);
+    }
+    @Test
+    @DisplayName("해당날짜의 창고의 모든 차량을 스케쥴표에 등록 (중복제외)")
+    void insertVehicleSchedule(){
+        VehicleDTO vehicleDTO = VehicleDTO.builder()
+                .storedType("냉장")
+                .warehouseCode("GG1")
+                .outboundDate(LocalDate.parse("2025-01-13"))
+                .outboundCode("OB005")
+                .quantity(45)
+                .build();
+        outboundService.insertVehicleSchedule(vehicleDTO);
+    }
+
+
+    @Test
+    @DisplayName("출고에 차량 배치")
+    void outboundVehicle(){
+        outboundService.outboundVehicle("OB156");
+        //결과 : 로그 확인
+    }
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- 관련된 이슈 번호를 작성해주세요. 예: #123 -->


## 📝 요약 (Summary)
1. 출고 승인 시 재고코드 재확인 및 부여 
2. 발주요청/출고완료 시 알람 발송 
3. 차량 배치 구현 

## 🛠️ 작업 내용

- [x] 발주 당시 재고 부족했다면, 재고 코드 null 처리 후 출고 승인 시 재확인 하여 재고코드 부여(창고관리자의 수동 입고 후 재고 증감했다면 승인 가능, 여전히 재고 부족 시 출고승인불가)

- [x] 건희님의 util을 사용하여 발주요청이 생성되거나 출고가 완료될 경우 메일 발송
      
- [x] 차량 배치 
    1. 스케줄표에 해당 날짜(+이전2일까지)에 창고 내의 모든 차량이 등록되어있는지 확인 (차량수와 등록된 수를 비교)
      1-1. 등록되어있지 않으면 해당 날짜(+이전2일까지)에 창고내의 모든 차량을 스케줄에 등록 (이미 등록된 차량 제외)
     > <br>매일/매달 모든 차량 등록 시 메모리저장공간이 낭비되므로 요청 발생 시 확인 후 필요한 날짜만 등록 
     > <br>차량스케줄과 창고(소유 차량)의 관계 모식도
     > <img width="514" height="404" alt="image" src="https://github.com/user-attachments/assets/61137729-9fe5-445a-b8a3-10943cc97d41" />


    2. 최적 차량
      2-1. 해당 창고 보유 차량 중
      2-2. 출고요청일 2일 이내에(우선순위 : 당일 > 하루전 > 이틀전)
      2-3. 제품과 보관타입 일치
      2-4. 잔여 적재용량 존재
      2-5. 제품 출고량 적재가능한 차량 중
      2-6. 가장 잔여 적재용량이 큰 차량 조회

    > <br>최적차량이 부족할 경우 무조건 출고불가 되는 상황을 방지하기 위해  출고일 포함 3일 검토
    > 그럼에도 불구하고 차량부족으로 출고 불가 시 발주 재요청해야함... (미구현)<br>

    3. 출고와 차량배치스케쥴에 반영(출고량 만큼 차량 적재용량에서 차감)
   
## ✅ PR 체크리스트

- [x] 커밋 메시지를 컨벤션에 맞게 작성했나요?
      
- [x] 로컬에서 테스트를 완료했나요?
      
- [x] 코드 스타일 가이드를 따랐나요?
